### PR TITLE
An ondat

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -98,7 +98,7 @@ BASE64PASSWORD=$(echo -n $PASSWORD | base64)
 
 Note that the Kubernetes secret containing a strong password *must* be created
 before bootstrapping the cluster. Multiple installation procedures use this
-Secret to create a Ondat account when the cluster first starts.
+Secret to create an Ondat account when the cluster first starts.
 
 ## Ondat Pod placement
 

--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -82,7 +82,7 @@ Kubernetes-style labels and selectors, prefixed with `storageos.com/`. By
 default, volumes are cached to improve read performance and compressed to
 reduce network traffic.
 
-Any pod may mount a Ondat virtual volume from any node that is also
+Any pod may mount an Ondat virtual volume from any node that is also
 running Ondat, regardless of whether the pod and volume are
 collocated on the same node. Therefore, applications may be started or
 restarted on any node and access volumes transparently.

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -13,7 +13,7 @@ weight: 1
 
 > Ondat supports the five most recent Kubernetes releases, at minimum.
 
-> Make sure to add a Ondat licence after installing.
+> Make sure to add an Ondat licence after installing.
 
 &nbsp;
 
@@ -324,4 +324,4 @@ StorageOSCluster. Check the kubectl plugin reference for the
 ## First Ondat volume
 
 If this is your first installation you may wish to follow the [Ondat Volume guide](/docs/operations/firstpvc) for an example of how
-to mount a Ondat volume in a Pod.
+to mount an Ondat volume in a Pod.

--- a/docs/install/openshift.md
+++ b/docs/install/openshift.md
@@ -15,7 +15,7 @@ weight: 20
 > If you have installed OpenShift in AWS ensure that the requisite ports are
 > opened for the worker nodes' security group.
 
-> Make sure to add a Ondat licence after installing.
+> Make sure to add an Ondat licence after installing.
 
 Ondat v2 supports OpenShift v4. For more information, see the [OpenShift platform](/docs/platforms/openshift) page.
 
@@ -321,4 +321,4 @@ To obtain a license, follow the instructions on our [licensing operations](/docs
 ## First Ondat volume
 
 If this is your first installation you may wish to follow the [Ondat volume guide](/docs/operations/firstpvc) for an example of how
-to mount a Ondat volume in a Pod.
+to mount an Ondat volume in a Pod.

--- a/docs/install/rancher.md
+++ b/docs/install/rancher.md
@@ -244,4 +244,4 @@ To obtain a license, follow the instructions on our [licensing operations](/docs
 ## First Ondat volume
 
 If this is your first installation you may wish to follow the [Ondat Volume guide](/docs/operations/firstpvc) for an example of how
-to mount a Ondat volume in a Pod.
+to mount an Ondat volume in a Pod.

--- a/docs/operations/fencing.md
+++ b/docs/operations/fencing.md
@@ -16,7 +16,7 @@ watches for node failures and determines if there are any pods targeted for
 fencing. In order for a pod to be fenced, the following criteria is required.
 
 * The pod must have the label `storageos.com/fenced=true`
-* The pod to be fenced must claim a Ondat volume
+* The pod to be fenced must claim an Ondat volume
 * The Ondat volume claimed by the pod needs to be `online`
 
 If the node becomes offline and these criteria are met, the pod is deleted and

--- a/docs/operations/label-stos-objects.md
+++ b/docs/operations/label-stos-objects.md
@@ -14,7 +14,7 @@ Kubernetes Cluster needs to be synced to your Ondat cluster.
 
 The below guide shows how to apply a label to your PVCs, and how these labels
 sync through to your Ondat Volumes. This operation is used often - for
-example it is used here to add replicas to a Ondat Volume.
+example it is used here to add replicas to an Ondat Volume.
 
 1. Create a PVC, following the instructions [here](/docs/operations/firstpvc). 
 When you create a PVC, Ondat

--- a/docs/operations/namespaces.md
+++ b/docs/operations/namespaces.md
@@ -3,7 +3,7 @@ title: "Namespaces"
 linkTitle: Namespaces
 ---
 
-Namespaces help different projects or teams share a Ondat cluster. Only the
+Namespaces help different projects or teams share an Ondat cluster. Only the
 default namespace is created by default.
 
 Namespaces apply to volumes.

--- a/docs/operations/trim.md
+++ b/docs/operations/trim.md
@@ -5,7 +5,7 @@ linkTitle: TRIM
 
 Ondat volumes support TRIM/Unmap by default for all uncompressed volumes.
 Ondat creates uncompressed volumes by default so all of these volumes will
-support TRIM/Unmap calls. TRIM'ing a Ondat volume will release space taken
+support TRIM/Unmap calls. TRIM'ing an Ondat volume will release space taken
 up by deleted blocks in the Ondat volume blob files.
 
 TRIM can either be called periodically via `fstrim` or continously using the
@@ -17,7 +17,7 @@ In order to TRIM a volume you can run `fstrim` against the volume filesystem.
 The volume filesystem will be presented at the mount point for the Ondat
 device.
 
-The example below shows the effect of `fstrim` on a Ondat volume mounted on
+The example below shows the effect of `fstrim` on an Ondat volume mounted on
 `/mnt`.
 ```
 # A Ondat volume with some data written to it.

--- a/docs/prerequisites/max-AIO.md
+++ b/docs/prerequisites/max-AIO.md
@@ -6,7 +6,7 @@ weight: 500
 
 As part of the dataplane operation, Ondat uses Linux AIO (Asynchronous
 Input Output) contexts to serve I/O requests without blocking. Ondat
-requires 4 AIO contexts per deployment (i.e. a Ondat volume deployment,
+requires 4 AIO contexts per deployment (i.e. an Ondat volume deployment,
 whether master or replica).
 
 ## Max AIO prerequisite.

--- a/docs/reference/bundles/support_bundle.md
+++ b/docs/reference/bundles/support_bundle.md
@@ -64,7 +64,7 @@ kubectl storageos bundle /tmp/storageos-kubectl-config.yaml
 should update the bundle-configuration.yaml under
 `spec.collectors.run.nodeselector` to reflect this.
 
-Note also that the bundle tool expects there to be a Ondat CLI running in
+Note also that the bundle tool expects there to be an Ondat CLI running in
 kube-system as a Pod with the label `run=cli`. The tool will exec into this pod
 to get information from the Ondat API. If the Ondat CLI Pod does not
 match this criteria, you can either pull the YAML file and change the selector

--- a/docs/reference/cli/apply.md
+++ b/docs/reference/cli/apply.md
@@ -54,8 +54,8 @@ $ echo "<licence file contents>" | storageos apply licence --from-stdin
 
 Flags:
       --cas string         make changes to a resource conditional upon matching the provided version
-      --from-file string   reads a Ondat product licence from a specified file path
-      --from-stdin         reads a Ondat product licence from the standard input
+      --from-file string   reads an Ondat product licence from a specified file path
+      --from-stdin         reads an Ondat product licence from the standard input
   -h, --help               help for licence
 
 Global Flags:

--- a/docs/reference/cluster-operator/_index.md
+++ b/docs/reference/cluster-operator/_index.md
@@ -9,8 +9,8 @@ developed to deploy and configure Ondat clusters, and assist with
 maintenance operations. We recommend its use for standard installations. 
 
 The operator acts as a Kubernetes controller that watches the `StorageOSCluster`
-CR (Custom Resource). Once the controller is ready, a Ondat cluster definition can be
-created. The operator will deploy a Ondat cluster based on the
+CR (Custom Resource). Once the controller is ready, an Ondat cluster definition can be
+created. The operator will deploy an Ondat cluster based on the
 configuration specified in the cluster definition.
 
 You can find the source code in the [cluster-operator
@@ -18,7 +18,7 @@ repository](https://github.com/storageos/cluster-operator).
 
 Install the operator following orchestrator specific procedure.
 
-To deploy a Ondat cluster you will need to fulfil the following steps.
+To deploy an Ondat cluster you will need to fulfil the following steps.
 
 1. Install Etcd
 1. Install operator

--- a/docs/reference/cluster-operator/examples.md
+++ b/docs/reference/cluster-operator/examples.md
@@ -4,7 +4,7 @@ linkTitle: Examples
 weight: 30
 ---
 
-Before deploying a Ondat cluster, create a Secret to define the Ondat
+Before deploying an Ondat cluster, create a Secret to define the Ondat
 API Username and Password in base64 encoding.
 
 ```bash

--- a/docs/reference/kubernetes-object-sync.md
+++ b/docs/reference/kubernetes-object-sync.md
@@ -59,7 +59,7 @@ triggered when the Kubernetes node is removed.
 Whenever a node delete event occurs the Node Delete Controller will trigger if
 the node has the Ondat CSI driver annotation.
 
-If the node holds a Ondat Volume without a replica then it cannot be
+If the node holds an Ondat Volume without a replica then it cannot be
 deleted by this controller. The Volume must be deleted first and then the node.
 This is to prevent data loss by accidental deletion of a master volume. 
 

--- a/docs/reference/resource_requests_and_limits.md
+++ b/docs/reference/resource_requests_and_limits.md
@@ -13,9 +13,9 @@ CPU and Memory.
 As Ondat is an infrastructure component, the health of other applications
 depends on being able to write to the Ondat volumes. As such it is of
 paramount importance to avoid restarts of the Ondat DaemonSet Pods.
-Restarting a Ondat Pod results in the volumes of the node the Ondat Pod
+Restarting an Ondat Pod results in the volumes of the node the Ondat Pod
 is running on being marked as Read Only, and causes the failover of primary
-volumes on that node to their replicas. After a Ondat Pod restart, once the
+volumes on that node to their replicas. After an Ondat Pod restart, once the
 Ondat DaemonSet Pod is "READY", the application Pods running on the node
 need to be restarted in order to trigger a mount of the filesystem hosted on
 the Ondat volume and resume normal operations. To avoid restarts of the

--- a/docs/reference/scheduler/admission-controller.md
+++ b/docs/reference/scheduler/admission-controller.md
@@ -15,7 +15,7 @@ Scheduler - `storageos-scheduler`.
 
 During Pod creation, Kubernetes sends a web request to the Ondat
 WebHook with the Pod specification. The PodSpec is only altered to use the
-Ondat scheduler if the Pod uses a Ondat volume.
+Ondat scheduler if the Pod uses an Ondat volume.
 
 ## Web Server
 

--- a/docs/reference/telemetry.md
+++ b/docs/reference/telemetry.md
@@ -50,7 +50,7 @@ The DNS query includes:
 
 The once per day report contains information about the Ondat cluster and
 Kubernetes versions to help Ondat focus our development efforts on the most
-popular platforms. The once per day data is encrypted and sent to a Ondat
+popular platforms. The once per day data is encrypted and sent to an Ondat
 telemetry server so it is never processed outside of Ondat assets.
 
 An exhaustive list of information included in the once per day report is below:

--- a/docs/self-eval.md
+++ b/docs/self-eval.md
@@ -178,7 +178,7 @@ developer license is free, and supports up to 5TiB of provisioned storage.
 To obtain a license, follow the instructions on our [licensing operations](operations/licensing.md) page.
 
 
-## Provision a Ondat Volume
+## Provision an Ondat Volume
 
 Now that we have a working Ondat cluster, we can provision a volume to test
 everything is working as expected.
@@ -246,7 +246,7 @@ everything is working as expected.
     $ kubectl get pod d1 -w
     ```
 
-    The pod mounts a Ondat volume under `/mnt` so any files written there
+    The pod mounts an Ondat volume under `/mnt` so any files written there
     will persist beyond the lifetime of the pod. This can be demonstrated using
     the following commands.
 
@@ -537,7 +537,7 @@ best results, test using your application of choice with a representative
 configuration and real world data.
 
 As an example of benchmarking an application the following steps lay out how to
-benchmark a Postgres database backed by a Ondat volume.
+benchmark a Postgres database backed by an Ondat volume.
 
 1. Start by cloning the Ondat use cases repository. Note this is the same
    repository that we cloned earlier so if you already have a copy just `cd

--- a/docs/usecases/cassandra.md
+++ b/docs/usecases/cassandra.md
@@ -12,7 +12,7 @@ fails, the cluster is only in a degraded state for as long as it takes
 Kubernetes to restart the pod. When the pod comes back up the pod data is
 immediately available. Should Kubernetes schedule the Cassandra pod on a
 new node, Ondat allows for the data to be available to the pod,
-irrespective of whether or not a Ondat master is located on the same node.
+irrespective of whether or not an Ondat master is located on the same node.
 
 As Cassandra has features to allow it to handle replication careful
 consideration of whether to allow Ondat or Cassandra to handle replication

--- a/docs/usecases/kubevirt.md
+++ b/docs/usecases/kubevirt.md
@@ -18,7 +18,7 @@ running off the PersistentVolume. [Containerized Data Importer
 (CDI)](https://github.com/kubevirt/containerized-data-importer) can also be
 used to prepare Ondat volumes with disk images in an automated fashion.
 Simply by declaring that a `VirtualMachine` will use a DataVolume and providing
-the disk image URL, a Ondat volume can be dynamically provisioned and
+the disk image URL, an Ondat volume can be dynamically provisioned and
 automatically prepared with the disk image.
 
 This usecase will guide you through installing KubeVirt and CDI on your
@@ -101,7 +101,7 @@ enabled.
 
 1. Check that the `VMI` is running. Note that the
    `VMI` will only be created after CDI has downloaded the
-   Cirros disk image onto a Ondat persistent volume so depending on your
+   Cirros disk image onto an Ondat persistent volume so depending on your
    connection speed this may take some time.
 
    ```bash

--- a/docs/usecases/sidecar-backups.md
+++ b/docs/usecases/sidecar-backups.md
@@ -4,7 +4,7 @@ linkTitle: Sidecar Backups
 ---
 
 In this example use case we provide three different strategies for accessing
-files that have been written to a Ondat  persistent volume.
+files that have been written to an Ondat  persistent volume.
 
 In the following examples the "application" container is the container `main`,
 which has a rsync, [Nginx](https://www.nginx.com/) or sftp sidecar container. The Ondat volume that
@@ -13,7 +13,7 @@ files written by the application are available for export. Files can be
 exported using Nginx as a web file server, transferred using rsync or accessed
 via SFTP.
 
-The files create a stateful set that can be used *AFTER* a Ondat cluster
+The files create a stateful set that can be used *AFTER* an Ondat cluster
 has been created. [See our guide on how to install Ondat on Kubernetes for more
 information](/docs/install/kubernetes).
 

--- a/docs/usecases/velero-backups.md
+++ b/docs/usecases/velero-backups.md
@@ -45,7 +45,7 @@ Here are the prerequisites for running Velero in your Kubernetes cluster:
 1. Velero cli installed https://Velero.io/docs/main/basic-install/
 > Velero can also be installed from a helm chart
 
-## Install MinIO with a Ondat volume
+## Install MinIO with an Ondat volume
 
 1. First, make sure to clone the Ondat use cases repository and navigate to
 the Velero directory:


### PR DESCRIPTION
Successor to https://github.com/ondat/ondat.github.io/pull/8

---

Replace all instances of 'a Ondat' with 'an Ondat'