### PR TITLE
Fix title typo

### DIFF
--- a/docs/concepts/rwx.md
+++ b/docs/concepts/rwx.md
@@ -1,6 +1,6 @@
 ---
 title: "ReadWriteMany (RWX)"
-linkTitle: ReadWriteMany
+linkTitle: "ReadWriteMany (RWX)"
 ---
 
 # ReadWriteMany

--- a/docs/concepts/rwx.md
+++ b/docs/concepts/rwx.md
@@ -1,5 +1,5 @@
 ---
-title: "ReadWrteMany"
+title: "ReadWriteMany (RWX)"
 linkTitle: ReadWriteMany
 ---
 


### PR DESCRIPTION
- fixed typo in the ReadWriteMany title under the Concepts page.
- made title and link title consistent.