### PR TITLE
removed markdown header that is showing up as a duplicate

### DIFF
--- a/docs/concepts/rwx.md
+++ b/docs/concepts/rwx.md
@@ -3,8 +3,6 @@ title: "ReadWriteMany (RWX)"
 linkTitle: "ReadWriteMany (RWX)"
 ---
 
-# ReadWriteMany
-
 > ⚠️ Ondat Project edition is required to create RWX Volumes.
 
 Ondat supports ReadWriteMany (RWX) [access


### PR DESCRIPTION
- small fix: removed markdown header that is showing up as a duplicate when the page is rendered