### PR TITLE
Airgapped installation

### DIFF
--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -371,7 +371,7 @@ than 256G to fulfil the IOPS requirement.
     ETCD_URL=http://etcd-url-or-ips:2379
 
     # Install
-    ONDAT_VERSION=v2.5.0
+    ONDAT_VERSION=v2.6.0
     kubectl storageos install \
         --etcd-endpoints $ETCD_URL \
             --skip-etcd-endpoints-validation \

--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -1,0 +1,69 @@
+---
+title: "Airgapped installation"
+weight: 50
+---
+
+
+Clusters without access to the internet require to specifiy explicitly
+resources that otherwise are automated during the installation.
+
+- Pull OCI images to private docker registries
+- Retrieve and amend yaml for the Ondat cluster-operator and CRDs
+- Define the StorageOSCluster CustomResource yaml
+- (If apply) Retrieve and amend yaml for Etcd operator and Etcd CustomResource
+
+## 1. Images to pull into a private registry 
+
+There are 3 sets of images to pull, the Ondat operator image, the Images
+defined in the StorageOSCluster definition that define the images for each
+component of the cluster and, if apply, the images to run Etcd as Pods using
+the Etcd operator deployed by Ondaat. 
+
+- Ondat operator: `storageos/operator:v2.5.0`
+- Get the image list from the
+  [storageos-related-images configMap](https://github.com/storageos/operator/blob/main/bundle/manifests/storageos-related-images_v1_configmap.yaml)
+and select the branch for the version release of Ondat to be installed.
+- If you are installing Etcd in Kubernetes, then pull 
+	- quay.io/coreos/etcd:v3.5.0
+	- storageos/etcd-cluster-operator-controller:develop
+	- storageos/etcd-cluster-operator-proxy:develop
+
+
+## 2. Cluster operator yaml
+
+The Ondat operator yamls are generated for every release of the product. It is
+best to retrieve the yaml for the machine generated pipeline. To do so, the
+following container prints it through stdout.
+
+Run locally:
+```
+ONDAT_VERSION=v2.5.0
+docker run --rm storageos/operator-manifests:$ONDAT_VERSION > ondat-operator.yaml
+```
+
+Or run in a k8s cluster:
+```
+ONDAT_VERSION=v2.5.0
+
+# Once the image is pulled into your registry you can run
+kubectl run operator-manifests --image storageos/operator-manifests:$ONDAT_VERSION 
+
+# Get the yaml
+kubectl logs operator-manifests > ondat-operator.yaml
+
+# Clean
+kubectl delete pod operator-manifests
+```
+
+Once you have the `ondat-operator.yaml` you must edit the file to amend the
+container image URL for the private registry one. 
+```
+ONDAT_VERSION=v2.5.0
+REGISTRY_IMG=my-registry-url/storageos/operator:$ONDAT_VERSION
+sed -i -e "s#image: storageos/operator:$ONDAT_VERSION#image: $REGISTRY_IMG#g" operator-manifests.yaml
+```
+
+## 3. Define StorageOSCluster CR
+
+## 4. (If Etcd in Kubernetes) Retrieve and amend the yaml for Etcd operator and Etcd CR
+

--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -34,7 +34,7 @@ and select the branch for the release version.
 
     ```bash
     # Images to pull
-    curl -s https://raw.githubusercontent.com/storageos/operator/release-v2.5.0/bundle/manifests/storageos-related-images_v1_configmap.yaml \
+    curl -s https://raw.githubusercontent.com/storageos/operator/release-v2.6.0/bundle/manifests/storageos-related-images_v1_configmap.yaml \
     | cut -d: -f2- \
     | grep ":v"
     ```

--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -32,13 +32,13 @@ and select the branch for the version release of Ondat to be installed.
 ## 2. Cluster operator yaml
 
 The Ondat operator yamls are generated for every release of the product. It is
-best to retrieve the yaml for the machine generated pipeline. To do so, the
-following container prints it through stdout.
+best to retrieve the yaml from the machine generated pipeline. To do so, the
+following container prints them on stdout.
 
 Run locally:
 ```
 ONDAT_VERSION=v2.5.0
-docker run --rm storageos/operator-manifests:$ONDAT_VERSION > ondat-operator.yaml
+docker run --rm storageos/ondat-operator-manifests:$ONDAT_VERSION > ondat-operator.yaml
 ```
 
 Or run in a k8s cluster:
@@ -46,10 +46,10 @@ Or run in a k8s cluster:
 ONDAT_VERSION=v2.5.0
 
 # Once the image is pulled into your registry you can run
-kubectl run operator-manifests --image storageos/operator-manifests:$ONDAT_VERSION 
+kubectl run ondat-operator-manifests --image storageos/operator-manifests:$ONDAT_VERSION 
 
 # Get the yaml
-kubectl logs operator-manifests > ondat-operator.yaml
+kubectl logs ondat-operator-manifests > ondat-operator.yaml
 
 # Clean
 kubectl delete pod operator-manifests
@@ -58,6 +58,8 @@ kubectl delete pod operator-manifests
 Once you have the `ondat-operator.yaml` you must edit the file to amend the
 container image URL for the private registry one. 
 ```
+# Change operator image for your registry url reference
+
 ONDAT_VERSION=v2.5.0
 REGISTRY_IMG=my-registry-url/storageos/operator:$ONDAT_VERSION
 sed -i -e "s#image: storageos/operator:$ONDAT_VERSION#image: $REGISTRY_IMG#g" operator-manifests.yaml
@@ -65,5 +67,231 @@ sed -i -e "s#image: storageos/operator:$ONDAT_VERSION#image: $REGISTRY_IMG#g" op
 
 ## 3. Define StorageOSCluster CR
 
+The StorageOSCluster definition depends on your cluster. Check the [operator
+reference](docs/reference/cluster-operator/configuration) for all the options
+available. For airgapped clusters, it is important to note the `spec.images`
+section that needs to be populated with the images from the configMap seen on step 1. 
+
+The file for the `ondat-cluster.yaml` should have the Secret called
+`storageos-api` and the StorageOSCluster definition.
+
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: storageos-api
+  namespace: storageos
+  labels:
+    app: storageos
+type: Opaque
+data:
+  password: c3RvcmFnZW9z # echo -n <username> | base64
+  username: c3RvcmFnZW9z # echo -n <username> | base64
+---
+# CR cluster definition
+apiVersion: storageos.com/v1
+kind: StorageOSCluster
+metadata:
+  name: storageos-cluster
+  namespace: "storageos"
+spec:
+  secretRefName: "storageos-api"
+  secretRefNamespace: "storageos"
+  k8sDistro: "upstream"
+  storageClassName: storageos
+  images:
+    nodeContainer: "storageos/node:v2.5.0
+    apiManagerContainer: storageos/api-manager:v1.2.2
+    initContainer: storageos/init:v2.1.0
+    csiNodeDriverRegistrarContainer: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
+    csiExternalProvisionerContainer: storageos/csi-provisioner:v2.1.1-patched
+    csiExternalAttacherContainer: quay.io/k8scsi/csi-attacher:v3.1.0
+    csiExternalResizerContainer: quay.io/k8scsi/csi-resizer:v1.1.0
+    csiLivenessProbeContainer: quay.io/k8scsi/livenessprobe:v2.2.0
+    kubeSchedulerContainer: k8s.gcr.io/kube-scheduler:v1.21.5
+  kvBackend:
+    address: "storageos-etcd-client.storageos:2379"
+#  nodeSelectorTerms:
+#    - matchExpressions:
+#      - key: "node-role.kubernetes.io/worker" # Compute node label will vary according to your installation
+#        operator: In
+#        values:
+#        - "true"
+```
+
+> ⚠️  The `kubeSchedulerContainer` version depends on the Kubernetes version your
+> cluster is running. In this example v1.21.5. Adjust the tag accordingly. 
+
+If you are using an external Etcd, skip step 4.
+
 ## 4. (If Etcd in Kubernetes) Retrieve and amend the yaml for Etcd operator and Etcd CR
 
+The yamls for etcd are generated for every release of the product. It is
+best to retrieve the yaml from the machine generated pipeline. To do so, the
+following container prints them on stdout.
+
+
+Run locally:
+```
+ETCD_OPERATOR_VERSION=develop
+docker run etcd-operator-manifests --rm storageos/operator-manifests:$ETCD_OPERATOR_VERSION > etcd-operator.yaml
+```
+
+Or run in a k8s cluster:
+```
+ETCD_OPERATOR_VERSION=develop
+
+# Once the image is pulled into your registry you can run
+kubectl run etcd-operator-manifests --image storageos/etcd-cluster-operator-manifests:develop
+
+# Get the yaml
+kubectl logs etcd-operator-manifests > etcd--operator.yaml
+
+# Clean
+kubectl delete pod etcd-operator-manifests
+```
+
+Once you have the `ondat-operator.yaml` you must edit the file to amend the
+container image URL for the private registry one. 
+
+```
+# Change the 2 images on the etcd-operator.yaml for your registry URL
+ETCD_OPERATOR_VERSION=develop
+
+# Etcd operator controller image
+REGISTRY_IMG_ETCD_OPERATOR=my-registry-url/storageos/etcd-operator:$ETCD_OPERATOR_VERSION
+sed -i -e "s#image: storageos/etcd-cluster-operator-controller:$ETCD_OPERATOR_VERSION#image: $REGISTRY_IMG_ETCD_OPERATOR#g" etcd-operator.yaml
+
+REGISTRY_IMG_ETCD_PROXY=my-registry-url/storageos/etcd-proxy:$ETCD_OPERATOR_VERSION
+sed -i -e "s#image: storageos/etcd-cluster-operator-proxy:$ETCD_OPERATOR_VERSION#image: $REGISTRY_IMG_ETCD_PROXY#g" etcd-operator.yaml
+
+# check the images are set correctly
+grep -C2 "image:" etcd-operator.yaml
+```
+
+Create the Etcd cluster definition, `etcd-cluster.yaml`.
+
+```yaml
+apiVersion: etcd.improbable.io/v1alpha1
+kind: EtcdCluster
+metadata:
+  name: storageos-etcd
+spec:
+  version: 3.5.0
+  podTemplate:
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: etcd.improbable.io/cluster-name
+                operator: In
+                values:
+                - storageos-etcd
+            topologyKey: kubernetes.io/hostname
+          weight: 100
+    etcdEnv:
+    - name: ETCD_HEARTBEAT_INTERVAL
+      value: "500"
+    - name: ETCD_ELECTION_TIMEOUT
+      value: "5000"
+    - name: ETCD_MAX_SNAPSHOTS
+      value: "10"
+    - name: ETCD_MAX_WALS
+      value: "10"
+    - name: ETCD_QUOTA_BACKEND_BYTES
+      value: "8589934592"
+    - name: ETCD_SNAPSHOT_COUNT
+      value: "100000"
+    - name: ETCD_AUTO_COMPACTION_RETENTION
+      value: "20000"
+    - name: ETCD_AUTO_COMPACTION_MODE
+      value: revision
+    resources:
+      limits:
+        cpu: 200m
+        memory: 200Mi
+      requests:
+        cpu: 200m
+        memory: 200Mi
+  replicas: 3
+  storage:
+    volumeClaimTemplate:
+      resources:
+        requests:
+          storage: 128Gi
+      storageClassName: local-path
+  tls:
+    enabled: false
+    storageOSClusterNamespace: storageos
+    storageOSEtcdSecretName: storageos-etcd-secret
+```
+
+
+## 5. Install the cluster
+
+Once all the yamls are ready, the Ondat cluster can be bootstrapped. 
+
+### Option 1: With etcd in Kubernetes
+
+The etcd cluster in Kubernetes requires an StorageClass. If you are running on
+a cloud provider, you can use existing StorageClasses for it, i.e gp3 (AWS) or
+standard (GCE). Or you can create the local-path StorageClass. It is
+recommended to give etcd a backend disk that can sustain at least 800 IOPS. It
+is best to use provisioned IOPS when possible, otherwise make sure the size of
+the disk is big enough to fulfil the IOPS requirement when performance depends
+on IOPS per GB.  For instance, AWS would require a burstable EBS bigger than
+256G to fulfil the IOPS requirement.  
+
+⚠️  The `local-path` StorageClass is only recommended for non production
+clusters as the data of the etcd peers is susceptible of being lost on node
+failure.
+
+```bash
+# Local-path StorageClass
+# Not for production workloads
+kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
+```
+
+```bash
+ETCD_STORAGECLASS=my-storage-class
+# Edit the StorageClass for etcd
+sed -i -e "s/storageClassName: local-path/storageClassName: $ETCD_STORAGECLASS/g" etcd-cluster.yaml
+```
+
+
+```
+# Install (plugin installs Etcd and Ondat)
+ONDAT_VERSION=v2.5.0
+kubectl storageos install \
+	--include-etcd \
+	--etcd-storage-class $ETCD_STORAGECLASS \
+	--etcd-namespace storageos \
+	--etcd-operator-yaml etcd-operator.yaml \
+	--etcd-cluster-yaml etcd-cluster.yaml \
+  	--skip-etcd-endpoints-validation \
+	--stos-operator-yaml ondat-operator.yaml \
+	--stos-cluster-yaml ondat-cluster.yaml \
+	--stos-cluster-namespace storageos \
+	--stos-version $ONDAT_VERSION
+```
+
+### Option 2: With external etcd
+
+```
+# Set etcd url
+# You can define multiple etcd urls separated by commas
+# http://peer1:2379,http://peer2:2379,http://peer3:2379
+ETCD_URL=http://etcd-url-or-ips:2379 
+
+# Install
+ONDAT_VERSION=v2.5.0
+kubectl storageos install \
+	--etcd-endpoints $ETCD_URL \
+	--stos-operator-yaml ondat-operator.yaml \
+	--stos-cluster-yaml ondat-cluster.yaml \
+	--stos-cluster-namespace storageos \
+	--stos-version $ONDAT_VERSION
+```

--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -106,9 +106,9 @@ container image URL for the private registry one.
 
 The StorageOSCluster definition depends on your cluster. For all available
 options, check the [operator
-reference](docs/reference/cluster-operator/configuration). For airgapped
-clusters, it is important to note that `spec.images` section needs to be
-populated with the images from the configMap from Step 1.
+reference](https://docs.ondat.io/docs/reference/cluster-operator/configuration).
+For airgapped clusters, it is important to note that `spec.images` section
+needs to be populated with the images from the configMap from Step 1.
 
 The file for the `ondat-cluster.yaml` should have the Secret called
 `storageos-api` and the StorageOSCluster definition.

--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -346,7 +346,7 @@ than 256G to fulfil the IOPS requirement.
     ```bash
     # Install (the kubectl-storageos plugin installs Etcd and Ondat)
     ETCD_STORAGECLASS=my-storage-class
-    ONDAT_VERSION=v2.5.0
+    ONDAT_VERSION=v2.6.0
     kubectl storageos install \
         --include-etcd \
         --etcd-storage-class $ETCD_STORAGECLASS \

--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -191,9 +191,9 @@ than 256G to fulfil the IOPS requirement.
 
     Edit the file `storageos-operator.yaml` and change:
     - Find the `ConfigMap` called `storageos-related-images` and change the
-      URLs of the images adding your registry url prefix.
+      URLs of the images adding your registry URL prefix.
     - Find the `Deployment` called `storageos-operator` and change the `images`
-      of the 2 containers on it adding your registry url prefix. They are the
+      of the 2 containers on it adding your registry URL prefix. They are the
       containers `manager` and `kube-rbac-proxy`.
 
 1. (Optional) Amend the file `storageos-cluster.yaml`

--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -144,7 +144,7 @@ spec:
   k8sDistro: "upstream"
   storageClassName: storageos
   images:
-    nodeContainer: $REGISTRY/storageos/node:v2.5.0
+    nodeContainer: $REGISTRY/storageos/node:v2.6.0
     apiManagerContainer: $REGISTRY/storageos/api-manager:v1.2.2
     initContainer: $REGISTRY/storageos/init:v2.1.0
     csiNodeDriverRegistrarContainer: $REGISTRY/quay.io/k8scsi/csi-node-driver-registrar:v2.1.0

--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -62,7 +62,7 @@ is best to retrieve the YAML from the machine-generated pipeline. To do so, run
 locally the following container that prints them on stdout.
 
     ```bash
-    ONDAT_VERSION=v2.5.0
+    ONDAT_VERSION=v2.6.0
     docker run   \
         --rm \
         storageos/operator-manifests:$ONDAT_VERSION > ondat-operator.yaml

--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -25,7 +25,7 @@ There are the following sets of images to pull:
 - (if applicable) the images to run Etcd as Pods using the Etcd operator
   deployed by Ondat
 
-1. Install the Ondat operator: `storageos/operator:v2.5.0` and `quay.io/brancz/kube-rbac-proxy:v0.10.0`
+1. Install the Ondat operator: `storageos/operator:v2.6.0` and `quay.io/brancz/kube-rbac-proxy:v0.10.0`
 1. Pull the images from the list defined in the [storageos-related-images
   configMap](https://github.com/storageos/operator/blob/main/bundle/manifests/storageos-related-images_v1_configmap.yaml)
 and select the branch for the release version.

--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -204,7 +204,8 @@ than 256G to fulfil the IOPS requirement.
 
 ## Step 4. Pulling images into a private registry
 
-The images set on the previous steps need to be added to your registry.
+The images set on the previous steps need to be added to your registry. You can
+find them with:
 
 ```bash
 grep -E  "RELATED|image:" *.yaml

--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -106,7 +106,7 @@ container image URL for the private registry one.
 
 The StorageOSCluster definition depends on your cluster. For all available
 options, check the [operator
-reference](https://docs.ondat.io/docs/reference/cluster-operator/configuration).
+reference](/docs/reference/cluster-operator/configuration).
 For airgapped clusters, it is important to note that `spec.images` section
 needs to be populated with the images from the configMap from Step 1.
 

--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -3,6 +3,8 @@ title: "Airgapped installation"
 weight: 50
 ---
 
+> The following page is for Advanced users. The full procedure is estimated to
+> take ~60 minutes to completion.
 
 Clusters without access to the internet require to specifiy explicitly
 resources that otherwise are automated during the installation.
@@ -76,6 +78,8 @@ kubectl delete pod operator-manifests
 
 Once you have the `ondat-operator.yaml` you must edit the file to amend the
 container image URL for the private registry one. 
+
+> Edit the variables `REGISTRY_IMG_OPERATOR` and `REGISTRY_IMG_PROXY`
 ```
 # Change operator image for your registry url reference
 
@@ -100,6 +104,8 @@ section that needs to be populated with the images from the configMap seen on st
 The file for the `ondat-cluster.yaml` should have the Secret called
 `storageos-api` and the StorageOSCluster definition.
 
+
+> Edit the variable `REGISTRY`
 
 ```yaml
 # Set the registry URL
@@ -187,6 +193,8 @@ kubectl delete pod etcd-operator-manifests
 Once you have the `ondat-operator.yaml` you must edit the file to amend the
 container image URL for the private registry one. 
 
+> Edit the variables `REGISTRY_IMG_ETCD_OPERATOR` and `REGISTRY_IMG_ETCD_PROXY`
+
 ```
 # Change the 2 images on the etcd-operator.yaml for your registry URL
 ETCD_OPERATOR_VERSION=develop
@@ -208,6 +216,8 @@ reqistry url as an argument to the etcd operator.
 Add the flag `-
 --etcd-repository=$REGISTRY/quay.io/coreos/etcd`  in
 the args of the `manager` container defined in `etcd-operator.yaml`
+
+> Edit the variabled $REGISTRY
 
 ```
 REGISTRY=my-registry-url
@@ -313,6 +323,8 @@ failure.
 kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
 ```
 
+> Edit the variable `ETCD_STORAGECLASS`
+
 ```bash
 ETCD_STORAGECLASS=my-storage-class
 # Edit the StorageClass for etcd
@@ -320,6 +332,7 @@ sed -i -e "s/storageClassName: local-path/storageClassName: $ETCD_STORAGECLASS/g
 ```
 
 
+> Edit the variable `ETCD_STORAGECLASS`
 ```
 # Install (the kubectl-storageos plugin installs Etcd and Ondat)
 ETCD_STORAGECLASS=my-storage-class
@@ -339,6 +352,7 @@ kubectl storageos install \
 
 ### Option 2: With external etcd
 
+> Edit the variable `ETCD_URL`
 ```
 # Set etcd url
 # You can define multiple etcd urls separated by commas

--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -22,25 +22,28 @@ There are the following sets of images to pull:
 * (if applicable) the images to run Etcd as Pods using the Etcd operator deployed by Ondat
 
 1. Install the Ondat operator: `storageos/operator:v2.5.0` and `quay.io/brancz/kube-rbac-proxy:v0.10.0`
-2. Pull the images from the list defined in the [storageos-related-images
+1. Pull the images from the list defined in the [storageos-related-images
   configMap](https://github.com/storageos/operator/blob/main/bundle/manifests/storageos-related-images_v1_configmap.yaml)
 and select the branch for the release version.
-  For instance for the branch `release-v2.5.0`::
-  ```bash
-  # Images to pull
-  curl -s https://raw.githubusercontent.com/storageos/operator/release-v2.5.0/bundle/manifests/storageos-related-images_v1_configmap.yaml \
+
+	For instance for the branch `release-v2.5.0`:
+
+	```bash
+	# Images to pull
+	curl -s https://raw.githubusercontent.com/storageos/operator/release-v2.5.0/bundle/manifests/storageos-related-images_v1_configmap.yaml \
 	| cut -d: -f2- \
 	| grep ":v"
-  ```
- 3. Pull the image `k8s.gcr.io/kube-scheduler:v1.21.5` with the tag
+	```
+
+1. Pull the image `k8s.gcr.io/kube-scheduler:v1.21.5` with the tag
   matching your Kubernetes version. In this case k8s version `v1.21.5`.
 
-- If you are installing Etcd in Kubernetes, then pull 
+1. If you are installing Etcd in Kubernetes, then pull 
 	- quay.io/coreos/etcd:v3.5.0
 	- storageos/etcd-cluster-operator-controller:develop
 	- storageos/etcd-cluster-operator-proxy:develop
 
-> This page will follow the reference to the pulled images with the format
+> 💡 This page will follow the reference to the pulled images with the format
 > `<url-of-registry>/<fqdn-of-public-image>:<tag>`, even though it is common to
 > remove the qualified domain name from the image url in private registries
 > leaving the URI of the image as `<user/image>:<tag>`. Set the URL for the
@@ -54,55 +57,57 @@ and select the branch for the release version.
 best to retrieve the YAML from the machine-generated pipeline. To do so, run locally the
 following container that prints them on stdout.
 
-```
-ONDAT_VERSION=v2.5.0
-docker run   \
-	--rm \
-	storageos/operator-manifests:$ONDAT_VERSION > ondat-operator.yaml
-```
+    ```
+    ONDAT_VERSION=v2.5.0
+    docker run   \
+        --rm \
+        storageos/operator-manifests:$ONDAT_VERSION > ondat-operator.yaml
+    ```
 
-Or run in a k8s cluster:
-```
-ONDAT_VERSION=v2.5.0
+    Or run in a k8s cluster:
+    ```
+    ONDAT_VERSION=v2.5.0
 
-# Once the image is pulled into your registry you can run
-kubectl run ondat-operator-manifests --image storageos/operator-manifests:$ONDAT_VERSION 
+    # Once the image is pulled into your registry you can run
+    kubectl run ondat-operator-manifests --image storageos/operator-manifests:$ONDAT_VERSION 
 
-# Get the yaml
-kubectl logs ondat-operator-manifests > ondat-operator.yaml
+    # Get the yaml
+    kubectl logs ondat-operator-manifests > ondat-operator.yaml
 
-# Clean
-kubectl delete pod operator-manifests
-```
+    # Clean
+    kubectl delete pod operator-manifests
+    ```
 
-2. Once you have the `ondat-operator.yaml` you must edit the file to amend the
+1. Once you have the `ondat-operator.yaml` you must edit the file to amend the
 container image URL for the private registry one. 
 
-> Edit the variables `REGISTRY_IMG_OPERATOR` and `REGISTRY_IMG_PROXY`
-```
-# Change operator image for your registry url reference
+    Edit the variables `REGISTRY_IMG_OPERATOR` and `REGISTRY_IMG_PROXY`
+    ```
+    # Change operator image for your registry url reference
 
-ONDAT_VERSION=v2.5.0
-REGISTRY_IMG_OPERATOR=my-registry-url/storageos/operator:$ONDAT_VERSION
-sed -i -e "s#image: storageos/operator:$ONDAT_VERSION#image: $REGISTRY_IMG_OPERATOR#g" ondat-operator.yaml
+    ONDAT_VERSION=v2.5.0
+    REGISTRY_IMG_OPERATOR=my-registry-url/storageos/operator:$ONDAT_VERSION
+    sed -i -e "s#image: storageos/operator:$ONDAT_VERSION#image: $REGISTRY_IMG_OPERATOR#g" ondat-operator.yaml
 
-REGISTRY_IMG_PROXY=my-registry-url/quay.io/brancz/kube-rbac-proxy:v0.10.0
-sed -i -e "s#image: quay.io/brancz/kube-rbac-proxy:v0.10.0#image: $REGISTRY_IMG_PROXY#g" ondat-operator.yaml
+    REGISTRY_IMG_PROXY=my-registry-url/quay.io/brancz/kube-rbac-proxy:v0.10.0
+    sed -i -e "s#image: quay.io/brancz/kube-rbac-proxy:v0.10.0#image: $REGISTRY_IMG_PROXY#g" ondat-operator.yaml
 
-# Check the change
-grep -C2 "image:" ondat-operator.yaml
-```
+    # Check the change
+    grep -C2 "image:" ondat-operator.yaml
+    ```
 
 ## Step 3. Defining StorageOSCluster CR
 
-* The StorageOSCluster definition depends on your cluster. For all available options, check the [operator
-reference](docs/reference/cluster-operator/configuration). For airgapped clusters, it is important to note that `spec.images`
-section needs to be populated with the images from the configMap from Step 1. 
+The StorageOSCluster definition depends on your cluster. For all available
+options, check the [operator
+reference](docs/reference/cluster-operator/configuration). For airgapped
+clusters, it is important to note that `spec.images` section needs to be
+populated with the images from the configMap from Step 1. 
 
-* The file for the `ondat-cluster.yaml` should have the Secret called
+The file for the `ondat-cluster.yaml` should have the Secret called
 `storageos-api` and the StorageOSCluster definition.
 
-Edit the variable `REGISTRY`
+Edit the variable `REGISTRY` and change the `username` and `password` secret strings.
 
 ```yaml
 # Set the registry URL
@@ -118,8 +123,8 @@ metadata:
     app: storageos
 type: Opaque
 data:
-  password: c3RvcmFnZW9z # echo -n <username> | base64
-  username: c3RvcmFnZW9z # echo -n <username> | base64
+  password: c3RvcmFnZW9z # echo -n storageos | base64
+  username: c3RvcmFnZW9z # echo -n storageos | base64
 ---
 # CR cluster definition
 apiVersion: storageos.com/v1
@@ -163,133 +168,135 @@ If you are using an external Etcd, skip Step 4.
 1. The YAMLs for Etcd are generated for every release of the product. It is
 best to retrieve the YAML from the machine generated pipeline. To do so, run the following container that prints them on stdout.
 
-```
-ETCD_OPERATOR_VERSION=develop
-docker run   \
-	--rm \
-	storageos/etcd-cluster-operator-manifests:$ETCD_OPERATOR_VERSION > etcd-operator.yaml
-```
+    ```
+    ETCD_OPERATOR_VERSION=develop
+    docker run   \
+        --rm \
+        storageos/etcd-cluster-operator-manifests:$ETCD_OPERATOR_VERSION > etcd-operator.yaml
+    ```
 
-Or run in a k8s cluster:
-```
-ETCD_OPERATOR_VERSION=develop
+    Or run in a k8s cluster:
+    ```
+    ETCD_OPERATOR_VERSION=develop
 
-# Once the image is pulled into your registry you can run
-kubectl run etcd-operator-manifests --image storageos/etcd-cluster-operator-manifests:develop
+    # Once the image is pulled into your registry you can run
+    kubectl run etcd-operator-manifests --image storageos/etcd-cluster-operator-manifests:develop
 
-# Get the yaml
-kubectl logs etcd-operator-manifests > etcd-operator.yaml
+    # Get the yaml
+    kubectl logs etcd-operator-manifests > etcd-operator.yaml
 
-# Clean
-kubectl delete pod etcd-operator-manifests
-```
+    # Clean
+    kubectl delete pod etcd-operator-manifests
+    ```
 
-2. Once you have the `ondat-operator.yaml` you must edit the file to amend the
+1. Once you have the `ondat-operator.yaml` you must edit the file to amend the
 container image URL for the private registry one. 
 
-> Edit the variables `REGISTRY_IMG_ETCD_OPERATOR` and `REGISTRY_IMG_ETCD_PROXY`
+    Edit the variables `REGISTRY_IMG_ETCD_OPERATOR` and `REGISTRY_IMG_ETCD_PROXY`
 
-```
-# Change the 2 images on the etcd-operator.yaml for your registry URL
-ETCD_OPERATOR_VERSION=develop
+    ```
+    # Change the 2 images on the etcd-operator.yaml for your registry URL
+    ETCD_OPERATOR_VERSION=develop
+    REGISTRY_IMG_ETCD_OPERATOR=my-registry-url/storageos/etcd-cluster-operator-controller:$ETCD_OPERATOR_VERSION
+    REGISTRY_IMG_ETCD_PROXY=my-registry-url/storageos/etcd-cluster-operator-proxy:$ETCD_OPERATOR_VERSION
 
-# Etcd operator controller image
-REGISTRY_IMG_ETCD_OPERATOR=my-registry-url/storageos/etcd-cluster-operator-controller:$ETCD_OPERATOR_VERSION
-sed -i -e "s#image: storageos/etcd-cluster-operator-controller:$ETCD_OPERATOR_VERSION#image: $REGISTRY_IMG_ETCD_OPERATOR#g" etcd-operator.yaml
+    # Etcd operator controller image
+    sed -i -e "s#image: storageos/etcd-cluster-operator-controller:$ETCD_OPERATOR_VERSION#image: $REGISTRY_IMG_ETCD_OPERATOR#g" etcd-operator.yaml
 
-REGISTRY_IMG_ETCD_PROXY=my-registry-url/storageos/etcd-cluster-operator-proxy:$ETCD_OPERATOR_VERSION
-sed -i -e "s#image: storageos/etcd-cluster-operator-proxy:$ETCD_OPERATOR_VERSION#image: $REGISTRY_IMG_ETCD_PROXY#g" etcd-operator.yaml
+    # Etcd proxy operator
+    sed -i -e "s#image: storageos/etcd-cluster-operator-proxy:$ETCD_OPERATOR_VERSION#image: $REGISTRY_IMG_ETCD_PROXY#g" etcd-operator.yaml
 
-# check the images are set correctly
-grep -C2 "image:" etcd-operator.yaml
-```
+    # check the images are set correctly
+    grep -C2 "image:" etcd-operator.yaml
+    ```
 
-3. Once the images are set on the `etcd-operator.yaml` it is required to add the
+1. Once the images are set on the `etcd-operator.yaml` it is required to add the
 reqistry URL as an argument to the Etcd operator.
 
-Add the flag `-
---etcd-repository=$REGISTRY/quay.io/coreos/etcd`  in
-the args of the `manager` container defined in `etcd-operator.yaml`
+    Add the flag `-
+    --etcd-repository=$REGISTRY/quay.io/coreos/etcd`  in
+    the args of the `manager` container defined in `etcd-operator.yaml`
 
-4. Edit the variabled $REGISTRY
+    Edit the variable `$REGISTRY`
 
-```
-REGISTRY=my-registry-url
+    ```
+    REGISTRY=my-registry-url
 
-# Old 
-      - args:
-        - --enable-leader-election
-        - --proxy-url=storageos-proxy.storageos-etcd.svc
-        command:
-        - /manager
+    # Old 
+          - args:
+            - --enable-leader-election
+            - --proxy-url=storageos-proxy.storageos-etcd.svc
+            command:
+            - /manager
 
-# New
-      - args:
-        - --enable-leader-election
-        - --proxy-url=storageos-proxy.storageos-etcd.svc
-        - --etcd-repository=$REGISTRY/quay.io/coreos/etcd # Edit this line with your registry url
-        command:
-        - /manager
-```
+    # New
+          - args:
+            - --enable-leader-election
+            - --proxy-url=storageos-proxy.storageos-etcd.svc
+            - --etcd-repository=$REGISTRY/quay.io/coreos/etcd # Edit this line with your registry url
+            command:
+            - /manager
+    ```
 
-5. Create the Etcd cluster definition, `etcd-cluster.yaml`.
+1. Create the Etcd cluster definition, `etcd-cluster.yaml`.
 
-```yaml
-apiVersion: etcd.improbable.io/v1alpha1
-kind: EtcdCluster
-metadata:
-  name: storageos-etcd
-spec:
-  version: 3.5.0
-  podTemplate:
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-        - podAffinityTerm:
-            labelSelector:
-              matchExpressions:
-              - key: etcd.improbable.io/cluster-name
-                operator: In
-                values:
-                - storageos-etcd
-            topologyKey: kubernetes.io/hostname
-          weight: 100
-    etcdEnv:
-    - name: ETCD_HEARTBEAT_INTERVAL
-      value: "500"
-    - name: ETCD_ELECTION_TIMEOUT
-      value: "5000"
-    - name: ETCD_MAX_SNAPSHOTS
-      value: "10"
-    - name: ETCD_MAX_WALS
-      value: "10"
-    - name: ETCD_QUOTA_BACKEND_BYTES
-      value: "8589934592"
-    - name: ETCD_SNAPSHOT_COUNT
-      value: "100000"
-    - name: ETCD_AUTO_COMPACTION_RETENTION
-      value: "20000"
-    - name: ETCD_AUTO_COMPACTION_MODE
-      value: revision
-    resources:
-      limits:
-        cpu: 200m
-        memory: 200Mi
-      requests:
-        cpu: 200m
-        memory: 200Mi
-  replicas: 3
-  storage:
-    volumeClaimTemplate:
-      resources:
-        requests:
-          storage: 128Gi
-      storageClassName: local-path
-  tls:
-    enabled: false
-    storageOSClusterNamespace: storageos
-    storageOSEtcdSecretName: storageos-etcd-secret
-```
+    ```yaml
+    apiVersion: etcd.improbable.io/v1alpha1
+    kind: EtcdCluster
+    metadata:
+      name: storageos-etcd
+    spec:
+      version: 3.5.0
+      podTemplate:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: etcd.improbable.io/cluster-name
+                    operator: In
+                    values:
+                    - storageos-etcd
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+        etcdEnv:
+        - name: ETCD_HEARTBEAT_INTERVAL
+          value: "500"
+        - name: ETCD_ELECTION_TIMEOUT
+          value: "5000"
+        - name: ETCD_MAX_SNAPSHOTS
+          value: "10"
+        - name: ETCD_MAX_WALS
+          value: "10"
+        - name: ETCD_QUOTA_BACKEND_BYTES
+          value: "8589934592"
+        - name: ETCD_SNAPSHOT_COUNT
+          value: "100000"
+        - name: ETCD_AUTO_COMPACTION_RETENTION
+          value: "20000"
+        - name: ETCD_AUTO_COMPACTION_MODE
+          value: revision
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 200m
+            memory: 200Mi
+      replicas: 3
+      storage:
+        volumeClaimTemplate:
+          resources:
+            requests:
+              storage: 128Gi
+          storageClassName: local-path # local files on host disk
+
+      tls:
+        enabled: false
+        storageOSClusterNamespace: storageos
+        storageOSEtcdSecretName: storageos-etcd-secret
+    ```
 
 
 ## Step 5. Installing the cluster
@@ -307,59 +314,63 @@ the disk is big enough to fulfil the IOPS requirement when performance depends
 on IOPS per GB.  For example, AWS would require a burstable EBS bigger than
 256G to fulfil the IOPS requirement.  
 
-⚠️  The `local-path` StorageClass is only recommended for __non production__
-clusters as the data of the etcd peers is susceptible of being lost on node
-failure.
+1. Create StorageClass (if you don't have one available)
 
-```bash
-# Local-path StorageClass
-# Not for production workloads
-kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
-```
+    > ⚠️  The `local-path` StorageClass is only recommended for __non production__
+    clusters as the data of the etcd peers is susceptible to being lost on node
+    failure.
+
+    ```bash
+    # Local-path StorageClass
+    # Not for production workloads
+    kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
+    ```
 
 1. Edit the variable `ETCD_STORAGECLASS`
 
-```bash
-ETCD_STORAGECLASS=my-storage-class
-# Edit the StorageClass for etcd
-sed -i -e "s/storageClassName: local-path/storageClassName: $ETCD_STORAGECLASS/g" etcd-cluster.yaml
-```
+    ```bash
+    ETCD_STORAGECLASS=my-storage-class
+    # Edit the StorageClass for etcd
+    sed -i -e "s/storageClassName: local-path/storageClassName: $ETCD_STORAGECLASS/g" etcd-cluster.yaml
+    ```
 
 
-2. Edit the variable `ETCD_STORAGECLASS`
-```
-# Install (the kubectl-storageos plugin installs Etcd and Ondat)
-ETCD_STORAGECLASS=my-storage-class
-ONDAT_VERSION=v2.5.0
-kubectl storageos install \
-	--include-etcd \
-	--etcd-storage-class $ETCD_STORAGECLASS \
-	--etcd-namespace storageos \
-	--etcd-operator-yaml etcd-operator.yaml \
-	--etcd-cluster-yaml etcd-cluster.yaml \
-  	--skip-etcd-endpoints-validation \
-	--stos-operator-yaml ondat-operator.yaml \
-	--stos-cluster-yaml ondat-cluster.yaml \
-	--stos-cluster-namespace storageos \
-	--stos-version $ONDAT_VERSION
-```
+1. Edit the variable `ETCD_STORAGECLASS`
+
+    ```
+    # Install (the kubectl-storageos plugin installs Etcd and Ondat)
+    ETCD_STORAGECLASS=my-storage-class
+    ONDAT_VERSION=v2.5.0
+    kubectl storageos install \
+        --include-etcd \
+        --etcd-storage-class $ETCD_STORAGECLASS \
+        --etcd-namespace storageos \
+        --etcd-operator-yaml etcd-operator.yaml \
+        --etcd-cluster-yaml etcd-cluster.yaml \
+        --skip-etcd-endpoints-validation \
+        --stos-operator-yaml ondat-operator.yaml \
+        --stos-cluster-yaml ondat-cluster.yaml \
+        --stos-cluster-namespace storageos \
+        --stos-version $ONDAT_VERSION
+    ```
 
 ### Option 2: With external Etcd
 
 1. Edit the variable `ETCD_URL`
-```
-# Set etcd url
-# You can define multiple etcd urls separated by commas
-# http://peer1:2379,http://peer2:2379,http://peer3:2379
-ETCD_URL=http://etcd-url-or-ips:2379 
 
-# Install
-ONDAT_VERSION=v2.5.0
-kubectl storageos install \
-	--etcd-endpoints $ETCD_URL \
-        --skip-etcd-endpoints-validation \
-	--stos-operator-yaml ondat-operator.yaml \
-	--stos-cluster-yaml ondat-cluster.yaml \
-	--stos-cluster-namespace storageos \
-	--stos-version $ONDAT_VERSION
-```
+    ```
+    # Set etcd url
+    # You can define multiple etcd urls separated by commas
+    # http://peer1:2379,http://peer2:2379,http://peer3:2379
+    ETCD_URL=http://etcd-url-or-ips:2379 
+
+    # Install
+    ONDAT_VERSION=v2.5.0
+    kubectl storageos install \
+        --etcd-endpoints $ETCD_URL \
+            --skip-etcd-endpoints-validation \
+        --stos-operator-yaml ondat-operator.yaml \
+        --stos-cluster-yaml ondat-cluster.yaml \
+        --stos-cluster-namespace storageos \
+        --stos-version $ONDAT_VERSION
+    ```

--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -3,21 +3,22 @@ title: "Airgapped installation"
 weight: 50
 ---
 
-> The following page is for Advanced users. The full procedure is estimated to
+> The following page is for advanced users. The full procedure is estimated to
 > take ~60 minutes to complete.
 
 Clusters without access to the internet require you to explicitly specify the
-resources to be installed. To install Ondat on an airgapped cluster, you need
-to do the following:
+resources to be installed. For that reason the `storageos` kubectl plugin
+`--dry-run` flag generates all the yamls for your cluster. You can amend them
+with the images pulled to your private registry. To install Ondat on an
+airgapped cluster, you need
 
-- Pull OCI images to private Docker registries.
-- Retrieve and amend YAML for the Ondat cluster-operator and CRDs.
-- Define the StorageOSCluster CustomResource YAML.
-- (If applicable) Retrieve and amend YAML for Etcd operator and Etcd CustomResource.
+- Install the `storageos` kubectl plugin
+- Generate yaml manifests and amend for your use case
+- Pull OCI images to private registries.
+- Install Ondat on your cluster
 
-## Step 1. Pulling images into a private registry
-
-There are the following sets of images to pull:
+There are the following sets of images to pull that will be shown along the
+following steps.
 
 - the Ondat operator image
 - the images in the StorageOSCluster definition that define the images for each
@@ -25,290 +26,21 @@ There are the following sets of images to pull:
 - (if applicable) the images to run Etcd as Pods using the Etcd operator
   deployed by Ondat
 
-1. Install the Ondat operator: `storageos/operator:v2.6.0` and `quay.io/brancz/kube-rbac-proxy:v0.10.0`
-1. Pull the images from the list defined in the [storageos-related-images
-  configMap](https://github.com/storageos/operator/blob/main/bundle/manifests/storageos-related-images_v1_configmap.yaml)
-and select the branch for the release version.
+## Step 1. Install storageos kubectl plugin
 
-    For instance for the branch `release-v2.5.0`:
-
-    ```bash
-    # Images to pull
-    curl -s https://raw.githubusercontent.com/storageos/operator/release-v2.6.0/bundle/manifests/storageos-related-images_v1_configmap.yaml \
-    | cut -d: -f2- \
-    | grep ":v"
-    ```
-
-1. Pull the image `k8s.gcr.io/kube-scheduler:v1.21.5` with the tag
-  matching your Kubernetes version. In this case k8s version `v1.21.5`.
-
-1. If you are installing Etcd in Kubernetes, then pull
-    - quay.io/coreos/etcd:v3.5.0
-    - storageos/etcd-cluster-operator-controller:develop
-    - storageos/etcd-cluster-operator-proxy:develop
-
-> 💡 This page will follow the reference to the pulled images with the format
-> `<url-of-registry>/<fqdn-of-public-image>:<tag>`, even though it is common to
-> remove the qualified domain name from the image url in private registries
-> leaving the URI of the image as `<user/image>:<tag>`. Set the URL for the
-> images following the name pattern that suits your best practices. For
-> example, the image `quay.io/k8scsi/csi-attacher:v3.1.0` is tranformed to
-> `registry-service.registry.svc:5000/quay.io/k8scsi/csi-attacher:v3.1.0`
-
-## Step 2. Retrieving the Cluster operator YAML
-
-1. The Ondat operator YAMLs are generated for every release of the product. It
-is best to retrieve the YAML from the machine-generated pipeline. To do so, run
-locally the following container that prints them on stdout.
-
-    ```bash
-    ONDAT_VERSION=v2.6.0
-    docker run   \
-        --rm \
-        storageos/operator-manifests:$ONDAT_VERSION > ondat-operator.yaml
-    ```
-
-    Or run in a k8s cluster:
-
-    ```bash
-    ONDAT_VERSION=v2.5.0
-
-    # Once the image is pulled into your registry you can run
-    kubectl run ondat-operator-manifests --image storageos/operator-manifests:$ONDAT_VERSION
-
-    # Get the yaml
-    kubectl logs ondat-operator-manifests > ondat-operator.yaml
-
-    # Clean
-    kubectl delete pod operator-manifests
-    ```
-
-1. Once you have the `ondat-operator.yaml` you must edit the file to amend the
-container image URL for the private registry one.
-
-    Edit the variables `REGISTRY_IMG_OPERATOR` and `REGISTRY_IMG_PROXY`
-
-    ```bash
-    # Change operator image for your registry url reference
-
-    ONDAT_VERSION=v2.5.0
-    REGISTRY_IMG_OPERATOR=my-registry-url/storageos/operator:$ONDAT_VERSION
-    sed -i -e "s#image: storageos/operator:$ONDAT_VERSION#image: $REGISTRY_IMG_OPERATOR#g" ondat-operator.yaml
-
-    REGISTRY_IMG_PROXY=my-registry-url/quay.io/brancz/kube-rbac-proxy:v0.10.0
-    sed -i -e "s#image: quay.io/brancz/kube-rbac-proxy:v0.10.0#image: $REGISTRY_IMG_PROXY#g" ondat-operator.yaml
-
-    # Check the change
-    grep -C2 "image:" ondat-operator.yaml
-    ```
-
-## Step 3. Defining StorageOSCluster CR
-
-The StorageOSCluster definition depends on your cluster. For all available
-options, check the [operator
-reference](/docs/reference/cluster-operator/configuration).
-For airgapped clusters, it is important to note that `spec.images` section
-needs to be populated with the images from the configMap from Step 1.
-
-The file for the `ondat-cluster.yaml` should have the Secret called
-`storageos-api` and the StorageOSCluster definition.
-
-Edit the variable `REGISTRY` and change the `username` and `password` secret strings.
-
-```yaml
-# Set the registry URL
-REGISTRY=my-registry-url
-
-cat <<END > ondat-cluster.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: storageos-api
-  namespace: storageos
-  labels:
-    app: storageos
-type: Opaque
-data:
-  password: c3RvcmFnZW9z # echo -n storageos | base64
-  username: c3RvcmFnZW9z # echo -n storageos | base64
----
-# CR cluster definition
-apiVersion: storageos.com/v1
-kind: StorageOSCluster
-metadata:
-  name: storageos-cluster
-  namespace: "storageos"
-spec:
-  secretRefName: "storageos-api"
-  secretRefNamespace: "storageos"
-  k8sDistro: "upstream"
-  storageClassName: storageos
-  images:
-    nodeContainer: $REGISTRY/storageos/node:v2.6.0
-    apiManagerContainer: $REGISTRY/storageos/api-manager:v1.2.2
-    initContainer: $REGISTRY/storageos/init:v2.1.0
-    csiNodeDriverRegistrarContainer: $REGISTRY/quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
-    csiExternalProvisionerContainer: $REGISTRY/storageos/csi-provisioner:v2.1.1-patched
-    csiExternalAttacherContainer: $REGISTRY/quay.io/k8scsi/csi-attacher:v3.1.0
-    csiExternalResizerContainer: $REGISTRY/quay.io/k8scsi/csi-resizer:v1.1.0
-    csiLivenessProbeContainer: $REGISTRY/quay.io/k8scsi/livenessprobe:v2.2.0
-    kubeSchedulerContainer: $REGISTRY/k8s.gcr.io/kube-scheduler:v1.21.5
-  kvBackend:
-    address: "storageos-etcd-client.storageos:2379"
-#  nodeSelectorTerms:
-#    - matchExpressions:
-#      - key: "node-role.kubernetes.io/worker" # Compute node label will vary according to your installation
-#        operator: In
-#        values:
-#        - "true"
-END
+```bash
+curl -sSLo kubectl-storageos.tar.gz \
+    https://github.com/storageos/kubectl-storageos/releases/download/v1.1.0/kubectl-storageos_1.1.0_linux_amd64.tar.gz \
+    && tar -xf kubectl-storageos.tar.gz \
+    && chmod +x kubectl-storageos \
+    && sudo mv kubectl-storageos /usr/local/bin/ \
+    && rm kubectl-storageos.tar.gz
 ```
 
-> ⚠️  The `kubeSchedulerContainer` version depends on the Kubernetes version your
-> cluster is running. In this example v1.21.5. Adjust the tag accordingly.
+> 💡 You can find binaries for different architectures and systems in [kubectl
+> plugin](https://github.com/storageos/kubectl-storageos/releases).
 
-If you are using an external Etcd, skip Step 4.
-
-## Step 4. (If Etcd in Kubernetes) Retrieving and amending the YAML for Etcd operator and Etcd CR
-
-1. The YAMLs for Etcd are generated for every release of the product. It is
-best to retrieve the YAML from the machine generated pipeline. To do so, run
-the following container that prints them on stdout.
-
-    ```bash
-    ETCD_OPERATOR_VERSION=develop
-    docker run   \
-        --rm \
-        storageos/etcd-cluster-operator-manifests:$ETCD_OPERATOR_VERSION > etcd-operator.yaml
-    ```
-
-    Or run in a k8s cluster:
-
-    ```bash
-    ETCD_OPERATOR_VERSION=develop
-
-    # Once the image is pulled into your registry you can run
-    kubectl run etcd-operator-manifests --image storageos/etcd-cluster-operator-manifests:develop
-
-    # Get the yaml
-    kubectl logs etcd-operator-manifests > etcd-operator.yaml
-
-    # Clean
-    kubectl delete pod etcd-operator-manifests
-    ```
-
-1. Once you have the `ondat-operator.yaml` you must edit the file to amend the
-container image URL for the private registry one.
-
-    Edit the variables `REGISTRY_IMG_ETCD_OPERATOR` and `REGISTRY_IMG_ETCD_PROXY`
-
-    ```bash
-    # Change the 2 images on the etcd-operator.yaml for your registry URL
-    ETCD_OPERATOR_VERSION=develop
-    REGISTRY_IMG_ETCD_OPERATOR=my-registry-url/storageos/etcd-cluster-operator-controller:$ETCD_OPERATOR_VERSION
-    REGISTRY_IMG_ETCD_PROXY=my-registry-url/storageos/etcd-cluster-operator-proxy:$ETCD_OPERATOR_VERSION
-
-    # Etcd operator controller image
-    sed -i -e "s#image: storageos/etcd-cluster-operator-controller:$ETCD_OPERATOR_VERSION#image: $REGISTRY_IMG_ETCD_OPERATOR#g" etcd-operator.yaml
-
-    # Etcd proxy operator
-    sed -i -e "s#image: storageos/etcd-cluster-operator-proxy:$ETCD_OPERATOR_VERSION#image: $REGISTRY_IMG_ETCD_PROXY#g" etcd-operator.yaml
-
-    # check the images are set correctly
-    grep -C2 "image:" etcd-operator.yaml
-    ```
-
-1. Once the images are set on the `etcd-operator.yaml` it is required to add the
-reqistry URL as an argument to the Etcd operator.
-
-    Add the flag `-
-    --etcd-repository=$REGISTRY/quay.io/coreos/etcd`  in
-    the args of the `manager` container defined in `etcd-operator.yaml`
-
-    Edit the variable `$REGISTRY`
-
-    ```bash
-    REGISTRY=my-registry-url
-
-    # Old
-          - args:
-            - --enable-leader-election
-            - --proxy-url=storageos-proxy.storageos-etcd.svc
-            command:
-            - /manager
-
-    # New
-          - args:
-            - --enable-leader-election
-            - --proxy-url=storageos-proxy.storageos-etcd.svc
-            - --etcd-repository=$REGISTRY/quay.io/coreos/etcd # Edit this line with your registry url
-            command:
-            - /manager
-    ```
-
-1. Create the Etcd cluster definition, `etcd-cluster.yaml`.
-
-    ```yaml
-    apiVersion: etcd.improbable.io/v1alpha1
-    kind: EtcdCluster
-    metadata:
-      name: storageos-etcd
-    spec:
-      version: 3.5.0
-      podTemplate:
-        affinity:
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                  - key: etcd.improbable.io/cluster-name
-                    operator: In
-                    values:
-                    - storageos-etcd
-                topologyKey: kubernetes.io/hostname
-              weight: 100
-        etcdEnv:
-        - name: ETCD_HEARTBEAT_INTERVAL
-          value: "500"
-        - name: ETCD_ELECTION_TIMEOUT
-          value: "5000"
-        - name: ETCD_MAX_SNAPSHOTS
-          value: "10"
-        - name: ETCD_MAX_WALS
-          value: "10"
-        - name: ETCD_QUOTA_BACKEND_BYTES
-          value: "8589934592"
-        - name: ETCD_SNAPSHOT_COUNT
-          value: "100000"
-        - name: ETCD_AUTO_COMPACTION_RETENTION
-          value: "20000"
-        - name: ETCD_AUTO_COMPACTION_MODE
-          value: revision
-        resources:
-          limits:
-            cpu: 200m
-            memory: 200Mi
-          requests:
-            cpu: 200m
-            memory: 200Mi
-      replicas: 3
-      storage:
-        volumeClaimTemplate:
-          resources:
-            requests:
-              storage: 128Gi
-          storageClassName: local-path # local files on host disk
-
-      tls:
-        enabled: false
-        storageOSClusterNamespace: storageos
-        storageOSEtcdSecretName: storageos-etcd-secret
-    ```
-
-## Step 5. Installing the cluster
-
-Once all the YAMLs are ready, the Ondat cluster can be bootstrapped.
+## Step 2. Generate yaml manifests
 
 ### Option 1: With Etcd in Kubernetes
 
@@ -330,39 +62,101 @@ than 256G to fulfil the IOPS requirement.
     ```bash
     # Local-path StorageClass
     # Not for production workloads
-    kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
+
+    # Pull yaml
+    curl -SsLo local-path.yaml https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
+
+    # Pull the following images into your registry
+    grep "image:" local-path.yaml
+
+    # Add registry URL to the image
+    vi local-path.yaml
+    ...
+
+    # Create the storageclass
+    kubectl apply -f local-path.yaml
     ```
 
-1. Edit the variable `ETCD_STORAGECLASS`
+1. Generate yaml manifests
+    > The following command generates a directory called `storageos-dry-run`
+    > with the manifests.
 
     ```bash
-    ETCD_STORAGECLASS=my-storage-class
-    # Edit the StorageClass for etcd
-    sed -i -e "s/storageClassName: local-path/storageClassName: $ETCD_STORAGECLASS/g" etcd-cluster.yaml
-    ```
-
-1. Edit the variable `ETCD_STORAGECLASS`
-
-    ```bash
-    # Install (the kubectl-storageos plugin installs Etcd and Ondat)
+    # Generate yamls
     ETCD_STORAGECLASS=my-storage-class
     ONDAT_VERSION=v2.6.0
+    K8S_VERSTION=v1.22.6
+    USERNAME=storageos
+    PASSWORD=storageos
+
     kubectl storageos install \
         --include-etcd \
         --etcd-storage-class $ETCD_STORAGECLASS \
-        --etcd-namespace storageos \
-        --etcd-operator-yaml etcd-operator.yaml \
-        --etcd-cluster-yaml etcd-cluster.yaml \
         --skip-etcd-endpoints-validation \
-        --stos-operator-yaml ondat-operator.yaml \
-        --stos-cluster-yaml ondat-cluster.yaml \
-        --stos-cluster-namespace storageos \
-        --stos-version $ONDAT_VERSION
+        --k8s-version $K8S_VERSION \
+        --admin-username "$USERNAME" \
+        --admin-password "$PASSWORD" \
+        --dry-run
     ```
+
+1. Amend the file `etcd-operator.yaml`
+
+    ```bash
+    cd storageos-dry-run
+    vi etcd-operator.yaml
+    ...
+    ```
+
+    Edit the file `etcd-operator.yaml` and change:
+    - Find the 2 deployments `storageos-etcd-controller-manager` and
+      `storageos-etcd-proxy` and edit the images to set the registry url
+      prefix.
+    - Add the flag `--etcd-repository=$REGISTRY/quay.io/coreos/etcd`  in the
+      args of the `manager` container.
+
+        For example:
+
+        ```bash
+        REGISTRY=my-registry-url
+        # Old
+              - args:
+                - --enable-leader-election
+                - --proxy-url=storageos-proxy.storageos-etcd.svc
+                command:
+                - /manager
+
+        # New
+              - args:
+                - --enable-leader-election
+                - --proxy-url=storageos-proxy.storageos-etcd.svc
+                - --etcd-repository=$REGISTRY/quay.io/coreos/etcd # Edit this line with your registry url
+                command:
+                - /manager
+        ```
+
+1. Amend the file `etcd-cluster.yaml`
+
+    ```bash
+    vi etcd-cluster.yaml
+    ...
+        volumeClaimTemplate:
+          resources:
+            requests:
+              storage: 256Gi
+    ...
+    ```
+
+    Define the `storge` size of the Etcd volumes. The backend disk requires at
+    least 800 IOPS for etcd to work normally. If you are on a cloud provider
+    that enables IOPSxGB, it is recommended to use a big enough volume. For
+    instance, on AWS a 256GiB or a 50GiB GCE SSD persistent disk.
 
 ### Option 2: With external Etcd
 
-1. Edit the variable `ETCD_URL`
+1. Generate yaml manifests
+
+    > The following command generates a directory called `storageos-dry-run`
+    > with the manifests.
 
     ```bash
     # Set etcd url
@@ -370,13 +164,95 @@ than 256G to fulfil the IOPS requirement.
     # http://peer1:2379,http://peer2:2379,http://peer3:2379
     ETCD_URL=http://etcd-url-or-ips:2379
 
-    # Install
+    # Generate yamls
+    ETCD_STORAGECLASS=my-storage-class
     ONDAT_VERSION=v2.6.0
+    K8S_VERSTION=v1.22.6
+    USERNAME=storageos
+    PASSWORD=storageos
+
     kubectl storageos install \
         --etcd-endpoints $ETCD_URL \
-            --skip-etcd-endpoints-validation \
-        --stos-operator-yaml ondat-operator.yaml \
-        --stos-cluster-yaml ondat-cluster.yaml \
-        --stos-cluster-namespace storageos \
-        --stos-version $ONDAT_VERSION
+        --skip-etcd-endpoints-validation \
+        --k8s-version $K8S_VERSION \
+        --admin-username "$USERNAME" \
+        --admin-password "$PASSWORD" \
+        --dry-run
     ```
+
+## Step 3. Amend manifests
+
+1. Amend the file `storageos-operator.yaml`
+
+    ```bash
+    cd storageos-dry-run
+    vi storageos-operator.yaml
+    ```
+
+    Edit the file `storageos-operator.yaml` and change:
+    - Find the `ConfigMap` called `storageos-related-images` and change the
+      URLs of the images adding your registry url prefix.
+    - Find the `Deployment` called `storageos-operator` and change the `images`
+      of the 2 containers on it adding your registry url prefix. They are the
+      containers `manager` and `kube-rbac-proxy`.
+
+1. (Optional) Amend the file `storageos-cluster.yaml`
+    The StorageOSCluster definition depends on your cluster. For all available
+    options, check the [operator
+    reference](/docs/reference/cluster-operator/configuration). You can add
+    options such as tolerations, nodeSelectors, etc.
+
+## Step 4. Pulling images into a private registry
+
+The images set on the previous steps need to be added to your registry.
+
+```bash
+grep -E  "RELATED|image:" *.yaml
+```
+
+## Step 5. Install Ondat
+
+```bash
+# Create the operators and CRDs first
+find . -name '*-operator.yaml'  | xargs -I{} kubectl create -f {}
+
+# Create the CustomResources
+find . -name '*-cluster.yaml'  | xargs -I{} kubectl create -f {}
+```
+
+## Verify the installation
+
+1. Etcd
+
+    ```bash
+    $ kubectl -n storageos-etcd get pod
+    NAME                                                READY   STATUS    RESTARTS   AGE
+    storageos-etcd-0-l4scc                              1/1     Running   0          2m19s
+    storageos-etcd-1-mzrv7                              1/1     Running   0          2m19s
+    storageos-etcd-2-bq596                              1/1     Running   0          2m19s
+    storageos-etcd-controller-manager-f89d9dc47-dlvgb   1/1     Running   0          2m34s
+    storageos-etcd-proxy-55479b544c-qm6nf               1/1     Running   0          2m34s
+    ```
+
+2. Ondat
+
+    ```bash
+    $ kubectl -n storageos get pod
+    NAME                                     READY   STATUS    RESTARTS        AGE
+    storageos-api-manager-54df545cbf-fn9cq   1/1     Running   0               113s
+    storageos-api-manager-54df545cbf-vmc56   1/1     Running   1 (106s ago)    113s
+    storageos-csi-helper-65db657d7c-52rkj    3/3     Running   0               115s
+    storageos-node-v6tbg                     3/3     Running   2 (2m17s ago)   2m30s
+    storageos-node-wg9rq                     3/3     Running   2 (2m18s ago)   2m30s
+    storageos-node-zhhkz                     3/3     Running   2 (2m17s ago)   2m30s
+    storageos-operator-6fc687d97b-fjqhd      2/2     Running   0               2m55s
+    storageos-scheduler-7d66d44694-6n99d     1/1     Running   0               2m38s
+    ```
+
+    > The `storageos-node` damonset pods will restart until they can connect to
+    > etcd
+
+## Step 6. Licese the cluster
+
+A cluster can operate without a licence for 24h. Follow the
+[licensing](/docs/operations/licensing/) page to apply a licence to your cluster.


### PR DESCRIPTION
Ondat installation for airgapped clusters. 

This page intends to have the full self contained information to be able to deploy Ondat on a cluster without internet. With both etcd as pods and external. As a result the procedure is long and, due to the nature of complexity added for clusters without access to the internet, complex. Different steps described in this page can be simplified with code changes to be reported as feedback to the product. 

There are decisions made on the style that are up for debate, feel free to comment. For instance, there is a reference on how long it takes to run the procedure, the use of bash env variables with replaces, the fact that there are 2 ways of run the manifest containers (local with docker) and kubectl run, etc. Those are opinionated points that I put in place as I believe it helps the reader to be able to copy and paste as much as possible. Also there is repetition of variables for those who read diagonally or skip steps, so we make sure that the environment is set correctly every time. 

@aeroniero33 I believe that you tested on airgapped clusters, it would be great to get your insight on this PR
@mdeneva I crated the page on the installation section as a first class citizen. Let me know if it should be placed somewhere else.

@cvlc @chris-milsted @hubvu I tested the procedure on an airgapped cluster with both etcd as pods and etcd external using a private registry. Using the kubectl plugin from an arm based Mac. I believe I used the syntax of the commands such as `sed` as compatible as possible. It would be great to verify that it works on other platforms. 

@cannisondat @nolancon  FYI


