### PR TITLE
removed docker ee section

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -133,9 +133,3 @@ volume replicas are being used.
 
 Ondat exposes ports to operate. It is recommended that the [ports](/docs/prerequisites/firewalls) are not accessible from outside
 the scope of your cluster.
-
-## Ondat in Docker EE
-
-Ondat does not support running on Swarm nodes nor on mixed (Kubernetes and
-Swarm) nodes. Ondat volumes have to be provisioned and used from Kubernetes
-nodes.


### PR DESCRIPTION
- alongside https://github.com/ondat/documentation/pull/57 I have removed the Docker EE section from the Best Practices document.