### PR TITLE
Remove deprecated operator flags

### DIFF
--- a/docs/operations/etcd/storageos-secret-info.md
+++ b/docs/operations/etcd/storageos-secret-info.md
@@ -46,7 +46,6 @@ spec:
   namespace: "storageos"
   # External mTLS secured etcd cluster specific properties
   tlsEtcdSecretRefName: "etcd-client-tls"                                   # Secret containing etcd client certificates in the same
-                                                                            # namespace of the StorageOSCluster resource
   kvBackend:
     address: "https://storageos-etcd-cluster-client.storagos-etcd.svc:2379" # Etcd client service address.
     backend: "etcd"                                                         # Backend type

--- a/docs/operations/etcd/storageos-secret-info.md
+++ b/docs/operations/etcd/storageos-secret-info.md
@@ -45,7 +45,7 @@ spec:
     nodeContainer: "storageos/node:v2.6.0""
   namespace: "storageos"
   # External mTLS secured etcd cluster specific properties
-  tlsEtcdSecretRefName: "etcd-client-tls"                                   # Secret containing etcd client certificates on the
+  tlsEtcdSecretRefName: "etcd-client-tls"                                   # Secret containing etcd client certificates in the same
                                                                             # namespace of the StorageOSCluster resource
   kvBackend:
     address: "https://storageos-etcd-cluster-client.storagos-etcd.svc:2379" # Etcd client service address.

--- a/docs/operations/etcd/storageos-secret-info.md
+++ b/docs/operations/etcd/storageos-secret-info.md
@@ -45,8 +45,8 @@ spec:
     nodeContainer: "storageos/node:v2.6.0""
   namespace: "storageos"
   # External mTLS secured etcd cluster specific properties
-  tlsEtcdSecretRefName: "etcd-client-tls"                                   # Secret containing etcd client certificates
-  tlsEtcdSecretRefNamespace: "storageos"                                    # Make sure the NS of the Secret is the same as the Ondat cluster
+  tlsEtcdSecretRefName: "etcd-client-tls"                                   # Secret containing etcd client certificates on the
+                                                                            # namespace of the StorageOSCluster resource
   kvBackend:
     address: "https://storageos-etcd-cluster-client.storagos-etcd.svc:2379" # Etcd client service address.
     backend: "etcd"                                                         # Backend type

--- a/docs/reference/cluster-operator/configuration.md
+++ b/docs/reference/cluster-operator/configuration.md
@@ -38,7 +38,6 @@ The following table lists the configurable spec parameters of the StorageOSClust
 | `k8sDistro`                                 | The name of the Kubernetes distribution is use, e.g. `rancher` or `eks`                        |
 | `kvBackend.address`                         | Comma-separated list of addresses of external key-value store. (`1.2.3.4:2379,2.3.4.5:2379`)   |
 | `kvBackend.backend` (v2 deprecated)         | Name of the key-value store to use. Set to `etcd` for external key-value store.                | `embedded`
-| `namespace`                                 | Namespace where storageos cluster resources are created                                        | `kube-system`
 | `nodeSelectorTerms`                         | Set node selector for storageos pod placement                                                  |
 | `pause`                                     | Pause the operator for cluster maintenance                                                     | `false`
 | `resources`                                 | Set resource requirements for the containers                                                   |

--- a/docs/reference/cluster-operator/configuration.md
+++ b/docs/reference/cluster-operator/configuration.md
@@ -39,7 +39,6 @@ The following table lists the configurable spec parameters of the StorageOSClust
 | `kvBackend.address`                         | Comma-separated list of addresses of external key-value store. (`1.2.3.4:2379,2.3.4.5:2379`)   |
 | `kvBackend.backend` (v2 deprecated)         | Name of the key-value store to use. Set to `etcd` for external key-value store.                | `embedded`
 | `nodeSelectorTerms`                         | Set node selector for storageos pod placement                                                  |
-| `pause`                                     | Pause the operator for cluster maintenance                                                     | `false`
 | `resources`                                 | Set resource requirements for the containers                                                   |
 | `secretRefName`                             | Reference name of storageos secret                                                             |
 | `service.annotations`                       | Annotations of the Service used by the cluster                                                 |

--- a/docs/reference/cluster-operator/configuration.md
+++ b/docs/reference/cluster-operator/configuration.md
@@ -46,5 +46,4 @@ The following table lists the configurable spec parameters of the StorageOSClust
 | `sharedDir`                                 | Path to be shared with kubelet container when deployed as a pod                                | `/var/lib/kubelet/plugins/kubernetes.io~storageos`
 | `storageClassName`                          | The name of the default StorageClass created for Ondat volumes                             | `storageos`
 | `tlsEtcdSecretRefName`                      | Secret containing etcd client certificates                                                     |
-| `tlsEtcdSecretRefNamespace`                 | Namespace of the tlsEtcdSecretRefName                                                          |
 | `tolerations`                               | Set pod tolerations for storageos pod placement                                                |

--- a/docs/reference/cluster-operator/configuration.md
+++ b/docs/reference/cluster-operator/configuration.md
@@ -33,7 +33,7 @@ The following table lists the configurable spec parameters of the StorageOSClust
 | `kvBackend.backend` (v2 deprecated)         | Name of the key-value store to use. Set to `etcd` for external key-value store.                | `embedded`
 | `nodeSelectorTerms`                         | Set node selector for storageos pod placement                                                  |
 | `resources`                                 | Set resource requirements for the containers                                                   |
-| `secretRefName`                             | Reference name of storageos secret                                                             |
+| `secretRefName`                             | Reference name of storageos secret within the namespace                                                            |
 | `service.annotations`                       | Annotations of the Service used by the cluster                                                 |
 | `service.externalPort`                      | External port of the Service used by the cluster                                               | `5705`
 | `service.internalPort`                      | Internal port of the Service used by the cluster                                               | `5705`

--- a/docs/reference/cluster-operator/configuration.md
+++ b/docs/reference/cluster-operator/configuration.md
@@ -16,9 +16,7 @@ The following table lists the configurable spec parameters of the StorageOSClust
 | `csi.enableNodePublishCreds`                | Enable CSI node publish credentials                                                            | `false`
 | `csi.enableProvisionCreds`                  | Enable CSI provision credentials                                                               | `false`
 | `debug`                                     | Enable debug mode for all the cluster nodes                                                    | `false`
-| `disableTCMU`                               | Disable TCMU to allow co-existence with other TCMU users. Disabling TCMU degrades performance  | `false`
 | `disableTelemetry`                          | Disable telemetry reports                                                                      | `false`
-| `forceTCMU`                                 | Forces TCMU to be enabled or causes Ondat to abort startup                                 | `false`
 | `images.apiManagerContainer`                | Ondat API Manager container image                                                          | `storageos/api-manager:v1.0.0`
 | `images.csiClusterDriverRegistrarContainer` | CSI Cluster Driver Registrar Container image                                                   | `quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1`
 | `images.csiExternalAttacherContainer`       | CSI External Attacher Container image                                                          | `quay.io/k8scsi/csi-attacher:v1.0.1`

--- a/docs/reference/cluster-operator/configuration.md
+++ b/docs/reference/cluster-operator/configuration.md
@@ -17,7 +17,6 @@ The following table lists the configurable spec parameters of the StorageOSClust
 | `csi.enableProvisionCreds`                  | Enable CSI provision credentials                                                               | `false`
 | `debug`                                     | Enable debug mode for all the cluster nodes                                                    | `false`
 | `disableFencing`                            | Disable Pod fencing                                                                            | `false`
-| `disableScheduler`                          | Disable Ondat scheduler                                                                    | `false`
 | `disableTCMU`                               | Disable TCMU to allow co-existence with other TCMU users. Disabling TCMU degrades performance  | `false`
 | `disableTelemetry`                          | Disable telemetry reports                                                                      | `false`
 | `forceTCMU`                                 | Forces TCMU to be enabled or causes Ondat to abort startup                                 | `false`

--- a/docs/reference/cluster-operator/configuration.md
+++ b/docs/reference/cluster-operator/configuration.md
@@ -28,10 +28,6 @@ The following table lists the configurable spec parameters of the StorageOSClust
 | `images.kubeSchedulerContainer`             | Kube scheduler container image                                                                 | Default dependent on Scheduler version
 | `images.nfsContainer`                       | Ondat nfs container image                                                                  | `storageos/nfs:1.0.0`
 | `images.nodeContainer`                      | Ondat node container image                                                                 | `storageos/node:v2.6.0`
-| `ingress.annotations`                       | Annotations of the ingress used by the cluster                                                 |
-| `ingress.enable`                            | Enable ingress for the cluster                                                                 | `false`
-| `ingress.hostname`                          | Hostname to be used in cluster ingress                                                         | `storageos.local`
-| `ingress.tls`                               | Enable TLS for the ingress                                                                     | `false`
 | `k8sDistro`                                 | The name of the Kubernetes distribution is use, e.g. `rancher` or `eks`                        |
 | `kvBackend.address`                         | Comma-separated list of addresses of external key-value store. (`1.2.3.4:2379,2.3.4.5:2379`)   |
 | `kvBackend.backend` (v2 deprecated)         | Name of the key-value store to use. Set to `etcd` for external key-value store.                | `embedded`

--- a/docs/reference/cluster-operator/configuration.md
+++ b/docs/reference/cluster-operator/configuration.md
@@ -16,7 +16,6 @@ The following table lists the configurable spec parameters of the StorageOSClust
 | `csi.enableNodePublishCreds`                | Enable CSI node publish credentials                                                            | `false`
 | `csi.enableProvisionCreds`                  | Enable CSI provision credentials                                                               | `false`
 | `debug`                                     | Enable debug mode for all the cluster nodes                                                    | `false`
-| `disableFencing`                            | Disable Pod fencing                                                                            | `false`
 | `disableTCMU`                               | Disable TCMU to allow co-existence with other TCMU users. Disabling TCMU degrades performance  | `false`
 | `disableTelemetry`                          | Disable telemetry reports                                                                      | `false`
 | `forceTCMU`                                 | Forces TCMU to be enabled or causes Ondat to abort startup                                 | `false`

--- a/docs/reference/cluster-operator/configuration.md
+++ b/docs/reference/cluster-operator/configuration.md
@@ -42,7 +42,6 @@ The following table lists the configurable spec parameters of the StorageOSClust
 | `pause`                                     | Pause the operator for cluster maintenance                                                     | `false`
 | `resources`                                 | Set resource requirements for the containers                                                   |
 | `secretRefName`                             | Reference name of storageos secret                                                             |
-| `secretRefNamespace`                        | Namespace of storageos secret                                                                  |
 | `service.annotations`                       | Annotations of the Service used by the cluster                                                 |
 | `service.externalPort`                      | External port of the Service used by the cluster                                               | `5705`
 | `service.internalPort`                      | Internal port of the Service used by the cluster                                               | `5705`

--- a/docs/reference/cluster-operator/examples.md
+++ b/docs/reference/cluster-operator/examples.md
@@ -69,7 +69,7 @@ spec:
 
 If using Etcd with mTLS, it is required to create the secret with the TLS
 material on the same namespace as the StorageOSCluster resource. Reference it's
-name with the following parameter.
+name with the following parameter:
 
 ```yaml
 spec:

--- a/docs/reference/cluster-operator/examples.md
+++ b/docs/reference/cluster-operator/examples.md
@@ -74,7 +74,7 @@ name with the following parameter:
 ```yaml
 spec:
   # External mTLS secured etcd cluster specific properties
-  tlsEtcdSecretRefName: "storageos-etcd-secret" # Secret containing etcd client certificates
+  tlsEtcdSecretRefName: "storageos-etcd-secret" # Secret containing etcd client certificates, within the StorageOSCluster CR namespace
 ```
 
 Follow the [etcd operations](/docs/operations/etcd/storageos-secret-info) page to setup the

--- a/docs/reference/cluster-operator/examples.md
+++ b/docs/reference/cluster-operator/examples.md
@@ -71,7 +71,6 @@ If using Etcd with mTLS, it is required to create the secret with the TLS
 material on the same namspace as the StorageOSCluster resource. Reference its
 name with the following parameter.
 
-
 ```yaml
 spec:
   # External mTLS secured etcd cluster specific properties

--- a/docs/reference/cluster-operator/examples.md
+++ b/docs/reference/cluster-operator/examples.md
@@ -67,14 +67,15 @@ spec:
   # address: '10.42.15.23:2379,10.42.12.22:2379,10.42.13.16:2379' # You can specify individual IPs of the etcd servers
 ```
 
-If using Etcd with mTLS, you need to specify the secret that hold the
-certificates with the following parameters:
+If using Etcd with mTLS, it is required to create the secret with the TLS
+material on the same namspace as the StorageOSCluster resource. Reference its
+name with the following parameter.
+
 
 ```yaml
 spec:
   # External mTLS secured etcd cluster specific properties
   tlsEtcdSecretRefName: "storageos-etcd-secret" # Secret containing etcd client certificates
-  tlsEtcdSecretRefNamespace: "storageos"        # Make sure that the etcd secret is in the same NS as the Ondat cluster
 ```
 
 Follow the [etcd operations](/docs/operations/etcd/storageos-secret-info) page to setup the
@@ -104,36 +105,6 @@ spec:
 > differently to specify master vs workers. Node Taints are not enough to
 > make sure Ondat doesn't start in a node. The `JOIN` variable is defined
 > by the operator by selecting all the nodes that match the `nodeSelectorTerms`.
-
-## Enabling CSI
-
-```yaml
-spec:
-  csi:
-    enable: true
-    deploymentStrategy: deployment
-    enableProvisionCreds: true
-    enableControllerPublishCreds: true
-    enableNodePublishCreds: true
-    enableControllerExpandCreds: true
-```
-
-The credentials must be defined in the `storageos-api` Secret
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "storageos-api"
-  labels:
-    app: "storageos"
-type: "kubernetes.io/storageos"
-data:
-  # echo -n '<secret>' | base64
-  username: c3RvcmFnZW9z
-  password: c3RvcmFnZW9z
-
-```
 
 ## Specifying a shared directory for use with kubelet as a container
 

--- a/docs/reference/cluster-operator/examples.md
+++ b/docs/reference/cluster-operator/examples.md
@@ -68,7 +68,7 @@ spec:
 ```
 
 If using Etcd with mTLS, it is required to create the secret with the TLS
-material on the same namspace as the StorageOSCluster resource. Reference its
+material on the same namespace as the StorageOSCluster resource. Reference it's
 name with the following parameter.
 
 ```yaml


### PR DESCRIPTION
Following the code from the operator v2.6, there are a deprecated flags of the CustomResource that need to be removed

https://github.com/storageos/operator/blob/release/v2.6.0/api/v1/storageoscluster_types.go#L17