### PR TITLE
changes image to 2.6

### DIFF
--- a/docs/introduction/self-eval.md
+++ b/docs/introduction/self-eval.md
@@ -160,7 +160,7 @@ spec:
           value: storageos
         - name: STORAGEOS_PASSWORD
           value: storageos
-        image: storageos/cli:v2.5.0
+        image: storageos/cli:v2.6.0
         name: cli
 END
 ```


### PR DESCRIPTION
The self-eval still uses the 2.5 image for the cli. Bumping to 2.6.