### PR TITLE
Pin the local path provisioner version since master is broken

### DIFF
--- a/docs/install/airgapped-clusters.md
+++ b/docs/install/airgapped-clusters.md
@@ -64,7 +64,7 @@ than 256G to fulfil the IOPS requirement.
     # Not for production workloads
 
     # Pull yaml
-    curl -SsLo local-path.yaml https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
+    curl -SsLo local-path.yaml https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.21/deploy/local-path-storage.yaml
 
     # Pull the following images into your registry
     grep "image:" local-path.yaml

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -69,7 +69,7 @@ kubectl storageos install \
 > in production for best possible performance and stability.
 
 > ⚠️ This requires a default `StorageClass` in the Kubernetes cluster.
-> If the default isn't set, you may need to set up the [local-path](https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml)
+> If the default isn't set, you may need to set up the [local-path](https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.21/deploy/local-path-storage.yaml)
 > `StorageClass`. Note that this stores all data locally on the individual
 > nodes and is not recommended for production installations.
 

--- a/docs/introduction/self-eval.md
+++ b/docs/introduction/self-eval.md
@@ -81,7 +81,7 @@ The following procedure deploys a local-path StorageClass for the Ondat Etcd.
 > ⚠️  Note that this Etcd __is suitable for evaluation purposes only__. Do not use this cluster for production workloads.
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.21/deploy/local-path-storage.yaml
 ```
 
 > ⚠️ The `local-path` StorageClass does not guarantee data safety or availability.


### PR DESCRIPTION
Currently the master branch of the rancher local path provisioner is broken, this PR pins it to the current latest version of the provisioner that we know is still working fine.