### PR TITLE
Move release notes up hierarchy

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,7 @@
 ---
-title: "Release notes"
-linkTitle: Release notes
+title: "Release Notes"
+linkTitle: Release Notes
+weight: 150
 ---
 
 We recommend always using "tagged" versions of Ondat rather than "latest",


### PR DESCRIPTION
Please review the following:
- Release notes moving up hierarchy of the menu bar
- The page needs to be between Introduction and Concepts (using sorting by weight)

Note:
- Once this PR is merged a redirect needs to be set up : https://docs.ondat.io/docs/reference/release_notes/ to https://docs.ondat.io/docs/release-notes/