### PR TITLE
Update rancher install guide

### DIFF
--- a/docs/install/rancher.md
+++ b/docs/install/rancher.md
@@ -9,7 +9,7 @@ weight: 1
 This guide will demonstrate how to install Ondat onto a [Rancher Kubernetes Engine (RKE)](https://rancher.com/products/rke) cluster. Ondat can be installed on a RKE cluster through two different methods;
 
 1. Using the [Ondat kubectl plugin](/docs/reference/kubectl-plugin/).
-2. Using [Ondat's Helm chart](https://github.com/rancher/partner-charts/tree/main/charts/ondat-operator/ondat-operator) through [Rancher's Apps & Marketplace](https://rancher.com/docs/rancher/v2.6/en/helm-charts/).
+1. Using [Ondat's Helm chart](https://github.com/rancher/partner-charts/tree/main/charts/ondat-operator/ondat-operator) through [Rancher's Apps & Marketplace](https://rancher.com/docs/rancher/v2.6/en/helm-charts/).
 
 ## Prerequisites
 
@@ -38,22 +38,22 @@ This guide will demonstrate how to install Ondat onto a [Rancher Kubernetes Engi
 
 1. By default, a newly provisioned RKE cluster does not have any CSI driver deployed. Run the following commands against the cluster to deploy a [Local Path Provisioner](https://github.com/rancher/local-path-provisioner) to provide local storage for Ondat's embedded `etcd` cluster operator deployment.
 
-```bash
-kubectl apply --filename="https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.21/deploy/local-path-storage.yaml"
-```
+    ```bash
+    kubectl apply --filename="https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.21/deploy/local-path-storage.yaml"
+    ```
 
-2. Define and export the `ETCD_STORAGECLASS` environment variable so that value is `local-path`, which is the default StorageClass name for the Local Path Provisioner.
+1. Define and export the `ETCD_STORAGECLASS` environment variable so that value is `local-path`, which is the default StorageClass name for the Local Path Provisioner.
 
-```bash
-export ETCD_STORAGECLASS="local-path"
-```
+    ```bash
+    export ETCD_STORAGECLASS="local-path"
+    ```
 
-3. Verify that the Local Path Provisioner was successfully deployed and ensure that that the deployment is in a  `RUNNING`  status, run the following  `kubectl`  commands.
+1. Verify that the Local Path Provisioner was successfully deployed and ensure that that the deployment is in a  `RUNNING`  status, run the following  `kubectl`  commands.
 
-```bash
-kubectl get pod --namespace=local-path-storage
-kubectl get storageclass
-```
+    ```bash
+    kubectl get pod --namespace=local-path-storage
+    kubectl get storageclass
+    ```
 
 > ⚠️ The `local-path` StorageClass is only recommended for **non production** clusters as this stores all the data of the `etcd` peers locally which makes it susceptible to state being lost on node failures.
 
@@ -61,29 +61,29 @@ kubectl get storageclass
 
 * Run the following command to conduct preflight checks against the RKE cluster to validate that Ondat prerequisites have been met before attempting an installation.
 
-```bash
-kubectl storageos preflight
-```
+    ```bash
+    kubectl storageos preflight
+    ```
 
 #### Step 4 - Installing Ondat
 
 1. Define and export the `STORAGEOS_USERNAME` and `STORAGEOS_PASSWORD` environment variables that will be used to manage your Ondat instance.
 
-```bash
-export STORAGEOS_USERNAME="storageos"
-export STORAGEOS_PASSWORD="storageos"
-```
+    ```bash
+    export STORAGEOS_USERNAME="storageos"
+    export STORAGEOS_PASSWORD="storageos"
+    ```
 
-2. Run the following  `kubectl-storageos` plugin command to install Ondat.
+1. Run the following  `kubectl-storageos` plugin command to install Ondat.
 
-```bash
-kubectl storageos install \
-  --include-etcd \
-  --etcd-tls-enabled \
-  --etcd-storage-class="$ETCD_STORAGECLASS" \
-  --admin-username="$STORAGEOS_USERNAME" \
-  --admin-password="$STORAGEOS_PASSWORD"
-```
+    ```bash
+    kubectl storageos install \
+      --include-etcd \
+      --etcd-tls-enabled \
+      --etcd-storage-class="$ETCD_STORAGECLASS" \
+      --admin-username="$STORAGEOS_USERNAME" \
+      --admin-password="$STORAGEOS_PASSWORD"
+    ```
 
 * The installation process may take a few minutes.
 
@@ -91,11 +91,11 @@ kubectl storageos install \
 
 * Run the following `kubectl` commands to inspect Ondat's resources (the core components should all be in a `RUNNING` status)
 
-```bash
-kubectl get all --namespace=storageos
-kubectl get all --namespace=storageos-etcd
-kubectl get storageclasses | grep "storageos"
-```
+    ```bash
+    kubectl get all --namespace=storageos
+    kubectl get all --namespace=storageos-etcd
+    kubectl get storageclasses | grep "storageos"
+    ```
 
 ### Option B - Using Rancher's Apps & Marketplace
 
@@ -103,8 +103,8 @@ kubectl get storageclasses | grep "storageos"
 
 * Ensure that you have an `etcd` cluster deployed first before installing Ondat through the Helm chart located on Apps & Marketplace. There are two different methods listed below with instructions on how to deploy an `etcd` cluster;
 
- 1. [Embedded Deployment](https://docs.ondat.io/docs/prerequisites/etcd/#testing---installing-etcd-into-your-kubernetes-cluster) - deploy an `etcd` cluster operator into your RKE cluster, recommended for **non production** environments.
- 2. [External Deployment](https://docs.ondat.io/docs/prerequisites/etcd/#production---etcd-on-external-virtual-machines) - deploy an `etcd` cluster in dedicated virtual machines, recommended for **production** environments.
+    1. [Embedded Deployment](https://docs.ondat.io/docs/prerequisites/etcd/#testing---installing-etcd-into-your-kubernetes-cluster) - deploy an `etcd` cluster operator into your RKE cluster, recommended for **non production** environments.
+    1. [External Deployment](https://docs.ondat.io/docs/prerequisites/etcd/#production---etcd-on-external-virtual-machines) - deploy an `etcd` cluster in dedicated virtual machines, recommended for **production** environments.
 
 * Once you have an `etcd` cluster up and running, ensure that you note down the list of `etcd` endpoints as comma-separated values that will be used when configuring Ondat in **Step 3**.
   * For example, `203.0.113.10:2379,203.0.113.11:2379,203.0.113.12:2379`
@@ -112,45 +112,45 @@ kubectl get storageclasses | grep "storageos"
 #### Step 2 - Locate Ondat Operator Helm Chart
 
 1. In the Rancher UI, under the RKE cluster where Ondat will be deployed - select the **Menu** button in the top-left corner of the page and then select **Apps & Marketplace**.
-2. Under **Apps & Marketplace**, a **Charts** page will be displayed where you can locate the [Ondat Operator Helm chart](https://github.com/rancher/partner-charts/tree/main/charts/ondat-operator/ondat-operator) by searching for "**Ondat**" in the search filter box.
-3. Once you have located the Ondat Operator Helm chart, select the chart. This will direct you to a page showing you more information about the Ondat Operator and how to install it.
-4. Select the **Install** button.
+1. Under **Apps & Marketplace**, a **Charts** page will be displayed where you can locate the [Ondat Operator Helm chart](https://github.com/rancher/partner-charts/tree/main/charts/ondat-operator/ondat-operator) by searching for "**Ondat**" in the search filter box.
+1. Once you have located the Ondat Operator Helm chart, select the chart. This will direct you to a page showing you more information about the Ondat Operator and how to install it.
+1. Select the **Install** button.
 
 #### Step 3 - Customising & Installing The Helm Chart
 
 1. Upon selecting the **Install** button in the previous step, you will be directed to a page to configure the **Application Metadata**. Define the namespace and application name where Ondat will be deployed and click **Next**.
 
-| Parameter | Value            | Description                          |
-| --------- | ---------------- | ------------------------------------ |
-| Namespace | `storageos`      | Namespace name for the deployment.   |
-| Name      | `ondat-operator` | Application name for the deployment. |
+    | Parameter | Value            | Description                          |
+    | --------- | ---------------- | ------------------------------------ |
+    | Namespace | `storageos`      | Namespace name for the deployment.   |
+    | Name      | `ondat-operator` | Application name for the deployment. |
 
-2. The next page will allow you to configure the Ondat Operator through Helm chart values. Under **Edit Options**, you are provided with 3 configurable sections called;
+1. The next page will allow you to configure the Ondat Operator through Helm chart values. Under **Edit Options**, you are provided with 3 configurable sections called;
 
-* **Questions**
-* **Container Images**
-* **StorageOS Cluster**
+    * **Questions**
+    * **Container Images**
+    * **StorageOS Cluster**
 
-3. Select the **StorageOS Cluster** section. This will show you a form with configurable parameters that have predefined values for an Ondat deployment. Below are following parameters that will need to be populated before beginning the installation;
+1. Select the **StorageOS Cluster** section. This will show you a form with configurable parameters that have predefined values for an Ondat deployment. Below are following parameters that will need to be populated before beginning the installation;
 
-| Parameter                   | Value | Description                                                                                                                                                                                      |
-| --------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Password                    |       | Password of the StorageOS administrator account. Must be at least 8 characters long, for example > `storageos`                                                                                   |
-| External `etcd` address(es) |       | List of `etcd` endpoints as comma-separated values. Prefer multiple direct endpoints over a single load-balanced endpoint, for example > `203.0.113.10:2379,203.0.113.11:2379,203.0.113.12:2379` |
+    | Parameter                   | Value | Description                                                                                                                                                                                      |
+    | --------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+    | Password                    |       | Password of the StorageOS administrator account. Must be at least 8 characters long, for example > `storageos`                                                                                   |
+    | External `etcd` address(es) |       | List of `etcd` endpoints as comma-separated values. Prefer multiple direct endpoints over a single load-balanced endpoint, for example > `203.0.113.10:2379,203.0.113.11:2379,203.0.113.12:2379` |
 
-> 💡 **Advanced Users** - For users who are looking to make further customisations to the Helm chart through additional configurable parameters or import your own `StorageOSCluster` custom resource manifest, review the Ondat Operator [README.md](https://github.com/ondat/charts/blob/main/charts/ondat-operator/README.md) document, [Cluster Operator Configuration](/docs/reference/cluster-operator/configuration) and  [Cluster Operator Examples](/docs/reference/cluster-operator/examples) reference pages for more information.
+    > 💡 **Advanced Users** - For users who are looking to make further customisations to the Helm chart through additional configurable parameters or import your own `StorageOSCluster` custom resource manifest, review the Ondat Operator [README.md](https://github.com/ondat/charts/blob/main/charts/ondat-operator/README.md) document, [Cluster Operator Configuration](/docs/reference/cluster-operator/configuration) and  [Cluster Operator Examples](/docs/reference/cluster-operator/examples) reference pages for more information.
 
-4. Once the parameters have been successfully populated, select **Install** to deploy Ondat.
+1. Once the parameters have been successfully populated, select **Install** to deploy Ondat.
 
 #### Step 4 - Verifying Ondat Installation
 
 * Run the following `kubectl` commands to inspect Ondat's resources (the core components should all be in a `RUNNING` status)
 
-```bash
-kubectl get all --namespace=storageos
-kubectl get all --namespace=storageos-etcd  # only if the etcd cluster was deployed inside the RKE cluster.
-kubectl get storageclasses | grep "storageos"
-```
+    ```bash
+    kubectl get all --namespace=storageos
+    kubectl get all --namespace=storageos-etcd  # only if the etcd cluster was deployed inside the RKE cluster.
+    kubectl get storageclasses | grep "storageos"
+    ```
 
 ### Applying a Licence to the Cluster
 

--- a/docs/install/rancher.md
+++ b/docs/install/rancher.md
@@ -1,248 +1,155 @@
 ---
-title: "Rancher"
-linkTitle: "Rancher"
-weight: 30
+title: "Rancher Kubernetes Engine (RKE)"
+linkTitle: "Rancher Kubernetes Engine (RKE)"
+weight: 1
 --- 
 
-Ondat is a certified Rancher application. We offer two installation
-methods:
+## Overview
 
-* Rancher Catalogue - this is the easiest and requires just a few clicks
-* Manual - allowing more control and visibility
+This guide will demonstrate how to install Ondat onto a [Rancher Kubernetes Engine (RKE)](https://rancher.com/products/rke) cluster. Ondat can be installed on a RKE cluster through two different methods;
 
-> ⚠️ Before proceeding, ensure that you have followed our [prerequisites](/docs/prerequisites/).
+1. Using the [Ondat kubectl plugin](/docs/reference/kubectl-plugin/).
+2. Using [Ondat's Helm chart](https://github.com/rancher/partner-charts/tree/main/charts/ondat-operator/ondat-operator) through [Rancher's Apps & Marketplace](https://rancher.com/docs/rancher/v2.6/en/helm-charts/).
 
-> ⚠️ On Rancher, pay particular attention to
-> the OS version and image used - some platforms require extra mainline kernel
-> modules to be enabled.
+## Prerequisites
 
-## Catalog Install
+> ⚠️ Make sure you have met the minimum resource requirements for Ondat to successfully run. Review the main [Ondat prerequisites](/docs/prerequisites/) page for more information.
 
-Ondat is a Certified application in the [Rancher
-Catalog](https://rancher.com/docs/rancher/v2.0-v2.4/en/helm-charts/). You can install
-Ondat using the Rancher application install.
+> ⚠️ Make sure the following CLI utility is installed on your local machine and is available in your `$PATH`:
 
-Before completing the steps below, you will need an etcd cluster. For
-evaluation use our simple [test](/docs/prerequisites/etcd#testing) recipe.
-For production installations, follow our [production](/docs/prerequisites/etcd#production) recipe.
-Make a note of the etcd endpoint URL in either case.
+* [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 
-1. Select the `System` project of your cluster
+> ⚠️ Make sure to add an [Ondat licence](/docs/operations/licensing/) after installing.
 
-    ![install-1](/images/docs/rancher-ui-v2/rancher-1.png)
+> ⚠️ Make sure you have a running RKE cluster with a minimum of 3 worker nodes and the sufficient [Role-Based Access Control (RBAC)](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) permissions to deploy and manage applications in the cluster.
 
-2. Select the `Apps` tab and click `Launch`
+> ⚠️ Make sure your RKE cluster uses a Linux distribution that is officially supported by Rancher as your node operating system and has the required LinuxIO related kernel modules are available for Ondat to run successfully. A strong recommendation would be to review [SUSE Rancher Support Matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/) documentation to ensure that you are using a supported Linux distribution.
 
-    ![install-2](/images/docs/rancher-ui-v2/rancher-2.png)
+## Procedure
 
-3. Search for Ondat and click on the App
+### Option A - Using Ondat Kubectl Plugin
 
-    ![install-3](/images/docs/rancher-ui-v2/rancher-3.png)
+#### Step 1 - Install Ondat Kubectl Plugin
 
-    This will install the Ondat operator, which manages the Ondat
-    DaemonSet.
+* Ensure that the Ondat kubectl plugin is installed on your local machine and is available in your `$PATH`:
+	* [kubectl-storageos](/docs/reference/kubectl-plugin/)
 
-4. Check and ammend installation options
+#### Step 2 - Install Local Path Provisioner
 
-    A generic configuration for Ondat is preset using the default values in
-    the form. Be sure to check the etcd address and ensure it matches the value
-    you noted at the beginning of this guide.
+1. By default, a newly provisioned RKE cluster does not have any CSI driver deployed. Run the following commands against the cluster to deploy a [Local Path Provisioner](https://github.com/rancher/local-path-provisioner) to provide local storage for Ondat's embedded `etcd` cluster operator deployment.
 
-    The catalog form exposes several useful parameters - documented
-    [below](/docs/install/rancher#simplecustomization}).
-
-    For further customization, you can opt to set the option to 'Install
-    Ondat Cluster' to false and install a custom CR. See [below](/docs/install/rancher#advancedcustomization) for this.
-
-    ![install-4](/images/docs/rancher-ui-v2/rancher-4.png)
-
-5. Launch the Ondat cluster
-
-    ![install-8](/images/docs/rancher-ui-v2/rancher-8.png)
-
-6. Verify the cluster bootstrap has successfully completed
-
-    ![install-81](/images/docs/rancher-ui-v2/rancher-81.png)
-
-7. License the newly installed cluster
-
-    > ⚠️ Newly installed Ondat clusters must be licensed within 24 hours. Our
-    > personal license is free, and supports up to 1TiB of provisioned storage.
-
-    You will need access to the Ondat API on port 5705 of any of your nodes.
-    For convenience, it is often easiest to port forward the service using the
-    following kubectl incantation (this will block, so a second terminal window may
-    be advisable):
-
-      ```bash
-      kubectl port-forward -n storageos svc/storageos 5705
-      ```
-
-    Now follow the instructions on our [licensing operations](/docs/operations/licensing)
-    page to obtain and apply a license.
-
-    Installation of Ondat is now complete.
-
-### Simple Customization - Modify Catalog Form
-
-The following options are exposed by the catalog form to allow some simple
-customization of the Ondat installation.
-
-![install-5](/images/docs/rancher-ui-v2/rancher-5.png)
-![install-6](/images/docs/rancher-ui-v2/rancher-6.png)
-![install-7](/images/docs/rancher-ui-v2/rancher-7.png)
-
-* **Cluster Operator namespace**
-: The Kubernetes namespace where the [Ondat Cluster Operator](/docs/reference/cluster-operator/) and other resources will be
-created.
-* **Container Images** : By default images are pulled from DockerHub, you can
-* specify the image URLs
-when using private registries.
-* **Install Ondat cluster**
-: Controls the automatic deployment of Ondat after installing the Cluster
-Operator. If set to `false`, the Operator will be created, but a Custom Resource will
-not be applied to the cluster. Launch the operator and proceed to the section
-[Advanced Customization](/docs/install/rancher#advancedcustomization) below.
-* **Namespace** : The Kubernetes namespace where Ondat will be
-installed. By default, Ondat installs into the `storageos` namespace,
-which will add a priority class to ensure high priority resource allocation.
-Installing Ondat with the priority class prevents Ondat from being
-evicted during periods of resource contention. It is inadvisable to modify this
-under normal circumstances.
-* **Username/Password** : Default Username and Password for the admin account
-to be created at Ondat bootstrap. A random password will be generated by
-leaving the field empty or clicking the `Generate` button.
-* **External etcd address(es)** : Connection and configuration details for an
-external Etcd cluster.See our documentation [here](/docs/prerequisites/etcd).
-* **Node Selectors and Tolerations**
-: Control placement of Ondat DaemonSet Pods. Ondat will only be
-installed on the selected nodes.
-* **Tolerations** : Define any tolerations you wish the DaemonSet to observe.
-
-### Advanced Customization - Apply Custom CR
-
-If `Install Ondat Cluster` was set to `false`, Ondat will not be
-bootstrapped automatically. After the Ondat Operator is installed, you can
-now create a Custom Resource that describes the Ondat cluster.
-
-1. Select the `System Workloads` and `Import YAML`
-    ![install-9](/images/docs/rancher-ui-v2/rancher-9.png)
-
-1. Create the `Secret` and `CustomResource`
-    ![install-10](/images/docs/rancher-ui-v2/rancher-10.png)
-    ![install-11](/images/docs/rancher-ui-v2/rancher-11.png)
-    ![install-12](/images/docs/rancher-ui-v2/rancher-12.png)
-
-    This is an example.
-
-    ```bash
-    ---
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: "storageos-api"
-      labels:
-        app: "storageos"
-    type: "kubernetes.io/storageos"
-    data:
-      # echo -n '<secret>' | base64
-      username: c3RvcmFnZW9z
-      password: c3RvcmFnZW9z
-    ---
-    apiVersion: "storageos.com/v1"
-    kind: StorageOSCluster
-    metadata:
-      name: "storageos"
-    spec:
-      # Ondat Pods are in storageos NS by default
-      secretRefName: "storageos-api" # Reference from the Secret created in the previous step
-      k8sDistro: "rancher"
-      storageClassName: "ondat" # The storage class created by the Ondat operator is configurable
-      images:
-        nodeContainer: "storageos/node:v2.6.0" # Ondat version
-      kvBackend:
-        address: 'storageos-etcd-client.etcd:2379' # Example address, change for your etcd endpoint
-      # address: '10.42.15.23:2379,10.42.12.22:2379,10.42.13.16:2379' # You can set ETCD server ips
-      sharedDir: '/var/lib/kubelet/plugins/kubernetes.io~storageos' # Needed when Kubelet as a container
-      resources:
-        requests:
-          memory: "512Mi"
-      nodeSelectorTerms:
-        - matchExpressions:
-          - key: "node-role.kubernetes.io/worker" # Compute node label will vary according to your installation
-            operator: In
-            values:
-            - "true"
-    ```
-
-    > 💡 Additional `spec` parameters are available on the [Cluster Operator
-    > configuration](/docs/reference/cluster-operator/configuration) page.
-
-    > 💡 You can find more examples such as deployments referencing a external
-    > etcd kv store for Ondat in the [Cluster Operator examples](/docs/reference/cluster-operator/examples) page.
-
-## Manual Installation
-
-### Install the storageos kubectl plugin
-
-```
-curl -sSLo kubectl-storageos.tar.gz \
-    https://github.com/storageos/kubectl-storageos/releases/download/v1.0.0/kubectl-storageos_1.0.0_linux_amd64.tar.gz \
-    && tar -xf kubectl-storageos.tar.gz \
-    && chmod +x kubectl-storageos \
-    && sudo mv kubectl-storageos /usr/local/bin/ \
-    && rm kubectl-storageos.tar.gz
+```bash
+kubectl apply --filename="https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.21/deploy/local-path-storage.yaml"
 ```
 
-> 💡 You can find binaries for different architectures and systems in [kubectl
-> plugin](https://github.com/storageos/kubectl-storageos/releases).
+2. Define and export the `ETCD_STORAGECLASS` environment variable so that value is `local-path`, which is the default StorageClass name for the Local Path Provisioner.
 
-### Install Ondat
+```bash
+export ETCD_STORAGECLASS="local-path"
+```
+
+3. Verify that the Local Path Provisioner was successfully deployed and ensure that that the deployment is in a  `RUNNING`  status, run the following  `kubectl`  commands.
+
+```bash
+kubectl get pod --namespace=local-path-storage
+kubectl get storageclass
+```
+
+> ⚠️ The `local-path` StorageClass is only recommended for **non production** clusters as this stores all the data of the `etcd` peers locally which makes it susceptible to state being lost on node failures.
+
+#### Step 3 - Conducting Preflight Checks
+
+* Run the following command to conduct preflight checks against the RKE cluster to validate that Ondat prerequisites have been met before attempting an installation.
+
+```bash
+kubectl storageos preflight
+```
+
+#### Step 4 - Installing Ondat
+
+1. Define and export the `STORAGEOS_USERNAME` and `STORAGEOS_PASSWORD` environment variables that will be used to manage your Ondat instance.
+
+```bash
+export STORAGEOS_USERNAME="storageos"
+export STORAGEOS_PASSWORD="storageos"
+```
+
+2. Run the following  `kubectl-storageos` plugin command to install Ondat.
 
 ```bash
 kubectl storageos install \
-    --etcd-endpoints 'storageos-etcd-client.storageos-etcd:2379' \
-    --admin-username "myuser" \
-    --admin-password "my-password"
+  --include-etcd \
+  --etcd-tls-enabled \
+  --etcd-storage-class="$ETCD_STORAGECLASS" \
+  --admin-username="$STORAGEOS_USERNAME" \
+  --admin-password="$STORAGEOS_PASSWORD"
 ```
 
-> 💡 Define the etcd endpoints as a comma delimited list, e.g. 10.42.3.10:2379,10.42.1.8:2379,10.42.2.8:2379
+* The installation process may take a few minutes.
 
-> 💡 If the etcd endpoints are not defined, the plugin will promt you and
-> request the endpoints.
+#### Step 5 - Verifying Ondat Installation
 
-For more details on the installation options, check the [kubectl storageos plugin reference page](/docs/reference/kubectl-plugin).
-
-## Verify Ondat installation
-
-Ondat installs all its components in the `storageos` namespace.
+* Run the following `kubectl` commands to inspect Ondat's resources (the core components should all be in a `RUNNING` status)
 
 ```bash
-$ kubectl -n storageos get pod -w
-NAME                                     READY   STATUS    RESTARTS   AGE
-storageos-api-manager-65f5c9dbdf-59p2j   1/1     Running   0          36s
-storageos-api-manager-65f5c9dbdf-nhxg2   1/1     Running   0          36s
-storageos-csi-helper-65dc8ff9d8-ddsh9    3/3     Running   0          36s
-storageos-node-4njd4                     3/3     Running   0          55s
-storageos-node-5qnl7                     3/3     Running   0          56s
-storageos-node-7xc4s                     3/3     Running   0          52s
-storageos-node-bkzkx                     3/3     Running   0          58s
-storageos-node-gwp52                     3/3     Running   0          62s
-storageos-node-zqkk7                     3/3     Running   0          62s
-storageos-operator-8f7c946f8-npj7l       2/2     Running   0          64s
-storageos-scheduler-86b979c6df-wndj4     1/1     Running   0          64s
+kubectl get all --namespace=storageos
+kubectl get all --namespace=storageos-etcd
+kubectl get storageclasses | grep "storageos"
 ```
 
-> 💡 Wait until all the pods are ready. It usually takes ~60 seconds to complete
+### Option B - Using Rancher's Apps & Marketplace
 
-## License cluster
+#### Step 1 - Setup An `etcd` Cluster
 
-> ⚠️ Newly installed Ondat clusters must be licensed within 24 hours. Our
-> personal license is free, and supports up to 1TiB of provisioned storage.
+* Ensure that you have an `etcd` cluster deployed first before installing Ondat through the Helm chart located on Apps & Marketplace. There are two different methods listed below with instructions on how to deploy an `etcd` cluster;
+	1. [Embedded Deployment](https://docs.ondat.io/docs/prerequisites/etcd/#testing---installing-etcd-into-your-kubernetes-cluster) - deploy an `etcd` cluster operator into your RKE cluster, recommended for **non production** environments.
+	2. [External Deployment](https://docs.ondat.io/docs/prerequisites/etcd/#production---etcd-on-external-virtual-machines) - deploy an `etcd` cluster in dedicated virtual machines, recommended for **production** environments.
+* Once you have an `etcd` cluster up and running, ensure that you note down the list of `etcd` endpoints as comma-separated values that will be used when configuring Ondat in **Step 3**.
+	* For example, `203.0.113.10:2379,203.0.113.11:2379,203.0.113.12:2379`
 
-To obtain a license, follow the instructions on our [licensing operations](/docs/operations/licensing) page.
+#### Step 2 - Locate Ondat Operator Helm Chart
 
-## First Ondat volume
+1. In the Rancher UI, under the RKE cluster where Ondat will be deployed - select the **Menu** button in the top-left corner of the page and then select **Apps & Marketplace**.
+2. Under **Apps & Marketplace**, a **Charts** page will be displayed where you can locate the [Ondat Operator Helm chart](https://github.com/rancher/partner-charts/tree/main/charts/ondat-operator/ondat-operator) by searching for "**Ondat**" in the search filter box.
+3. Once you have located the Ondat Operator Helm chart, select the chart. This will direct you to a page showing you more information about the Ondat Operator and how to install it.
+4. Select the **Install** button. 
 
-If this is your first installation you may wish to follow the [Ondat Volume guide](/docs/operations/firstpvc) for an example of how
-to mount an Ondat volume in a Pod.
+#### Step 3 - Customising & Installing The Helm Chart 
+
+1. Upon selecting the **Install** button in the previous step, you will be directed to a page to configure the **Application Metadata**. Define the namespace and application name where Ondat will be deployed and click **Next**.
+
+| Parameter | Value          | Description                          |
+| --------- | -------------- | ------------------------------------ |
+| Namespace | storageos      | Namespace name for the deployment.   |
+| Name      | ondat-operator | Application name for the deployment. |
+
+2. The next page will allow you to configure the Ondat Operator through Helm chart values. Under **Edit Options**, you are provided with 3 configurable sections called;
+	* **Questions**
+	* **Container Images**
+	* **StorageOS Cluster**
+3. Select the **StorageOS Cluster** section. This will show you a form with configurable parameters that have pre-defined values for an Ondat deployment. Below are following parameters that will need to be populated before beginning the installation;
+
+| Parameter                   | Value | Description                                                                                                                                                                                      |
+| --------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Password                    |       | Password of the StorageOS administrator account. Must be at least 8 characters long, for example > `storageos`                                                                                   |
+| External `etcd` address(es) |       | List of `etcd` endpoints as comma-separated values. Prefer multiple direct endpoints over a single load-balanced endpoint, for example > `203.0.113.10:2379,203.0.113.11:2379,203.0.113.12:2379` |
+
+> 💡 **Advanced Users** - For users who are looking to make further customisations to the Helm chart through additional configurable parameters or import your own `StorageOSCluster` custom resource manifest, review the Ondat Operator [README.md](https://github.com/ondat/charts/blob/main/charts/ondat-operator/README.md) document, [Cluster Operator Configuration](/docs/reference/cluster-operator/configuration) and  [Cluster Operator Examples](/docs/reference/cluster-operator/examples) reference pages for more information.
+
+4. Once the parameters have been successfully populated, select **Install** to deploy Ondat.
+
+#### Step 4 - Verifying Ondat Installation
+
+* Run the following `kubectl` commands to inspect Ondat's resources (the core components should all be in a `RUNNING` status)
+
+```bash
+kubectl get all --namespace=storageos
+kubectl get all --namespace=storageos-etcd		# only if the etcd cluster was deployed inside the RKE cluster.
+kubectl get storageclasses | grep "storageos"
+```
+
+### Applying a Licence to the Cluster
+
+> ⚠️ Newly installed Ondat clusters must be licensed within 24 hours. Our personal licence is free, and supports up to 1 TiB of provisioned storage.
+
+To obtain a licence, follow the instructions on our [licensing operations](/docs/operations/licensing) page.

--- a/docs/install/rancher.md
+++ b/docs/install/rancher.md
@@ -32,7 +32,7 @@ This guide will demonstrate how to install Ondat onto a [Rancher Kubernetes Engi
 #### Step 1 - Install Ondat Kubectl Plugin
 
 * Ensure that the Ondat kubectl plugin is installed on your local machine and is available in your `$PATH`:
-	* [kubectl-storageos](/docs/reference/kubectl-plugin/)
+  * [kubectl-storageos](/docs/reference/kubectl-plugin/)
 
 #### Step 2 - Install Local Path Provisioner
 
@@ -102,19 +102,19 @@ kubectl get storageclasses | grep "storageos"
 #### Step 1 - Setup An `etcd` Cluster
 
 * Ensure that you have an `etcd` cluster deployed first before installing Ondat through the Helm chart located on Apps & Marketplace. There are two different methods listed below with instructions on how to deploy an `etcd` cluster;
-	1. [Embedded Deployment](https://docs.ondat.io/docs/prerequisites/etcd/#testing---installing-etcd-into-your-kubernetes-cluster) - deploy an `etcd` cluster operator into your RKE cluster, recommended for **non production** environments.
-	2. [External Deployment](https://docs.ondat.io/docs/prerequisites/etcd/#production---etcd-on-external-virtual-machines) - deploy an `etcd` cluster in dedicated virtual machines, recommended for **production** environments.
+ 1. [Embedded Deployment](https://docs.ondat.io/docs/prerequisites/etcd/#testing---installing-etcd-into-your-kubernetes-cluster) - deploy an `etcd` cluster operator into your RKE cluster, recommended for **non production** environments.
+ 2. [External Deployment](https://docs.ondat.io/docs/prerequisites/etcd/#production---etcd-on-external-virtual-machines) - deploy an `etcd` cluster in dedicated virtual machines, recommended for **production** environments.
 * Once you have an `etcd` cluster up and running, ensure that you note down the list of `etcd` endpoints as comma-separated values that will be used when configuring Ondat in **Step 3**.
-	* For example, `203.0.113.10:2379,203.0.113.11:2379,203.0.113.12:2379`
+  * For example, `203.0.113.10:2379,203.0.113.11:2379,203.0.113.12:2379`
 
 #### Step 2 - Locate Ondat Operator Helm Chart
 
 1. In the Rancher UI, under the RKE cluster where Ondat will be deployed - select the **Menu** button in the top-left corner of the page and then select **Apps & Marketplace**.
 2. Under **Apps & Marketplace**, a **Charts** page will be displayed where you can locate the [Ondat Operator Helm chart](https://github.com/rancher/partner-charts/tree/main/charts/ondat-operator/ondat-operator) by searching for "**Ondat**" in the search filter box.
 3. Once you have located the Ondat Operator Helm chart, select the chart. This will direct you to a page showing you more information about the Ondat Operator and how to install it.
-4. Select the **Install** button. 
+4. Select the **Install** button.
 
-#### Step 3 - Customising & Installing The Helm Chart 
+#### Step 3 - Customising & Installing The Helm Chart
 
 1. Upon selecting the **Install** button in the previous step, you will be directed to a page to configure the **Application Metadata**. Define the namespace and application name where Ondat will be deployed and click **Next**.
 
@@ -124,10 +124,10 @@ kubectl get storageclasses | grep "storageos"
 | Name      | ondat-operator | Application name for the deployment. |
 
 2. The next page will allow you to configure the Ondat Operator through Helm chart values. Under **Edit Options**, you are provided with 3 configurable sections called;
-	* **Questions**
-	* **Container Images**
-	* **StorageOS Cluster**
-3. Select the **StorageOS Cluster** section. This will show you a form with configurable parameters that have pre-defined values for an Ondat deployment. Below are following parameters that will need to be populated before beginning the installation;
+ * **Questions**
+ * **Container Images**
+ * **StorageOS Cluster**
+3. Select the **StorageOS Cluster** section. This will show you a form with configurable parameters that have predefined values for an Ondat deployment. Below are following parameters that will need to be populated before beginning the installation;
 
 | Parameter                   | Value | Description                                                                                                                                                                                      |
 | --------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -144,7 +144,7 @@ kubectl get storageclasses | grep "storageos"
 
 ```bash
 kubectl get all --namespace=storageos
-kubectl get all --namespace=storageos-etcd		# only if the etcd cluster was deployed inside the RKE cluster.
+kubectl get all --namespace=storageos-etcd  # only if the etcd cluster was deployed inside the RKE cluster.
 kubectl get storageclasses | grep "storageos"
 ```
 

--- a/docs/install/rancher.md
+++ b/docs/install/rancher.md
@@ -102,8 +102,10 @@ kubectl get storageclasses | grep "storageos"
 #### Step 1 - Setup An `etcd` Cluster
 
 * Ensure that you have an `etcd` cluster deployed first before installing Ondat through the Helm chart located on Apps & Marketplace. There are two different methods listed below with instructions on how to deploy an `etcd` cluster;
+
  1. [Embedded Deployment](https://docs.ondat.io/docs/prerequisites/etcd/#testing---installing-etcd-into-your-kubernetes-cluster) - deploy an `etcd` cluster operator into your RKE cluster, recommended for **non production** environments.
  2. [External Deployment](https://docs.ondat.io/docs/prerequisites/etcd/#production---etcd-on-external-virtual-machines) - deploy an `etcd` cluster in dedicated virtual machines, recommended for **production** environments.
+
 * Once you have an `etcd` cluster up and running, ensure that you note down the list of `etcd` endpoints as comma-separated values that will be used when configuring Ondat in **Step 3**.
   * For example, `203.0.113.10:2379,203.0.113.11:2379,203.0.113.12:2379`
 
@@ -124,9 +126,11 @@ kubectl get storageclasses | grep "storageos"
 | Name      | `ondat-operator` | Application name for the deployment. |
 
 2. The next page will allow you to configure the Ondat Operator through Helm chart values. Under **Edit Options**, you are provided with 3 configurable sections called;
- * **Questions**
- * **Container Images**
- * **StorageOS Cluster**
+
+* **Questions**
+* **Container Images**
+* **StorageOS Cluster**
+
 3. Select the **StorageOS Cluster** section. This will show you a form with configurable parameters that have predefined values for an Ondat deployment. Below are following parameters that will need to be populated before beginning the installation;
 
 | Parameter                   | Value | Description                                                                                                                                                                                      |

--- a/docs/install/rancher.md
+++ b/docs/install/rancher.md
@@ -118,10 +118,10 @@ kubectl get storageclasses | grep "storageos"
 
 1. Upon selecting the **Install** button in the previous step, you will be directed to a page to configure the **Application Metadata**. Define the namespace and application name where Ondat will be deployed and click **Next**.
 
-| Parameter | Value          | Description                          |
-| --------- | -------------- | ------------------------------------ |
-| Namespace | storageos      | Namespace name for the deployment.   |
-| Name      | ondat-operator | Application name for the deployment. |
+| Parameter | Value            | Description                          |
+| --------- | ---------------- | ------------------------------------ |
+| Namespace | `storageos`      | Namespace name for the deployment.   |
+| Name      | `ondat-operator` | Application name for the deployment. |
 
 2. The next page will allow you to configure the Ondat Operator through Helm chart values. Under **Edit Options**, you are provided with 3 configurable sections called;
  * **Questions**


### PR DESCRIPTION
### Overview 

- This is an update to the instructions on how to deploy Ondat on a RKE cluster.
- The 2 installation methods have been updated (**kubectl plugin install** and **apps & marketplace install**).

#### **kubectl plugin install**

- Is now the first option to install Ondat.
- added instructions on setting up a local path provisioner for an embedded etcd cluster deployment.

#### **Apps & Marketplace Install**

- Images have been replaced in favour of using text to describe the installation steps.
- explanations/yaml/images on configuration parameters and importing a custom resource in the install guide.has been removed to avoid introducing complexity and duplication of effort. Instead, I have referenced where to find the relevant information - https://github.com/ondat/charts/blob/main/charts/ondat-operator/README.md , https://docs.ondat.io/docs/reference/cluster-operator/configuration/ and https://docs.ondat.io/docs/reference/cluster-operator/upgrade/ respectively (for advanced users only). 
