### PR TITLE
Bump plugin version to 1.2.0

### DIFF
--- a/docs/install/declarative-install.md
+++ b/docs/install/declarative-install.md
@@ -157,7 +157,7 @@ This guide will demonstrate how to install Ondat onto a Kubernetes cluster decla
 
 #### Step 4 - Customising & Installing Ondat's Operator Helm Chart
 
-* There are two ways to conduct an installation with Helm, **declaratively** by creating a custom `values.yaml` and (recommended method) or **interactively** by using the `--set` flags to overwrite specific values for the deployment.
+* There are two ways to conduct an installation with Helm, **declaratively** by creating a custom `values.yaml` (recommended method) or **interactively** by using the `--set` flags to overwrite specific values for the deployment.
 
 > 💡 **Advanced Users** - For users who are looking to make further customisations to the Helm chart through additional configurable parameters or manually create your own `StorageOSCluster` custom resource manifest, review the Ondat Operator [README.md](https://github.com/ondat/charts/blob/main/charts/ondat-operator/README.md) document, [Cluster Operator Configuration](/docs/reference/cluster-operator/configuration) and  [Cluster Operator Examples](/docs/reference/cluster-operator/examples) reference pages for more information.
 
@@ -172,7 +172,7 @@ This guide will demonstrate how to install Ondat onto a Kubernetes cluster decla
         password: # for example -> storageos
     ```
 
-    * [`cluster.kvBackend.address`](https://github.com/ondat/charts/blob/main/charts/ondat-operator/values.yaml#L60-L62)
+    * [`cluster.kvBackend.address`](https://github.com/ondat/charts/blob/main/charts/ondat-operator/values.yaml#L71-L72)
 
     ```yaml
         # Key-Value store backend.

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -140,7 +140,7 @@ This guide will demonstrate how to install Ondat onto a [Kubernetes](https://kub
     kubectl get storageclasses | grep "storageos"
     ```
 
-### Applying a Licence to the Cluster
+## Applying a Licence to the Cluster
 
 > ⚠️ Newly installed Ondat clusters must be licensed within 24 hours. Our Free Forever tier supports up to 1 TiB of provisioned storage.
 

--- a/docs/reference/kubectl-plugin.md
+++ b/docs/reference/kubectl-plugin.md
@@ -15,7 +15,7 @@ weight: 1
 
 ```bash
 curl --silent --show-error --location --output kubectl-storageos.tar.gz \
-  https://github.com/storageos/kubectl-storageos/releases/download/v1.1.0/kubectl-storageos_1.1.0_linux_amd64.tar.gz \
+  https://github.com/storageos/kubectl-storageos/releases/download/v1.2.0/kubectl-storageos_1.2.0_linux_amd64.tar.gz \
   && tar --extract --file kubectl-storageos.tar.gz kubectl-storageos \
   && chmod +x kubectl-storageos \
   && sudo mv kubectl-storageos /usr/local/bin/ \
@@ -28,7 +28,7 @@ curl --silent --show-error --location --output kubectl-storageos.tar.gz \
 
 ```bash
 curl --silent --show-error --location --output kubectl-storageos.tar.gz \
-  https://github.com/storageos/kubectl-storageos/releases/download/v1.1.0/kubectl-storageos_1.1.0_darwin_amd64.tar.gz \
+  https://github.com/storageos/kubectl-storageos/releases/download/v1.2.0/kubectl-storageos_1.2.0_darwin_amd64.tar.gz \
   && tar --extract --verbose --file kubectl-storageos.tar.gz kubectl-storageos \
   && chmod +x kubectl-storageos \
   && sudo mv kubectl-storageos /usr/local/bin/ \
@@ -41,7 +41,7 @@ curl --silent --show-error --location --output kubectl-storageos.tar.gz \
 
 ```bash
 # PowerShell
-Invoke-WebRequest https://github.com/storageos/kubectl-storageos/releases/download/v1.1.0/kubectl-storageos_1.1.0_windows_amd64.tar.gz -OutFile kubectl-storageos.tar.gz `
+Invoke-WebRequest https://github.com/storageos/kubectl-storageos/releases/download/v1.2.0/kubectl-storageos_1.2.0_windows_amd64.tar.gz -OutFile kubectl-storageos.tar.gz `
   ; tar -xf kubectl-storageos.tar.gz kubectl-storageos.exe `
   ; Remove-Item kubectl-storageos.tar.gz `
   ; Write-Host "Plugin version installed:" `


### PR DESCRIPTION
- bumping `kubectl-storageos` plugin version to 1.2.0
- small typo and url fixes to other documents