### PR TITLE
Remove extra steps in EKS install

### DIFF
--- a/docs/install/amazon-web-services-eks.md
+++ b/docs/install/amazon-web-services-eks.md
@@ -76,8 +76,6 @@ managedNodeGroups:
       echo "/dev/nvme1n1 /var/lib/storageos ext4 defaults,discard 0 1" >> /etc/fstab
       mkfs.ext4 /dev/nvme1n1
       mount /var/lib/storageos
-      sudo apt-get update
-      sudo apt-get install -y linux-modules-extra-$(uname -r)
       /etc/eks/bootstrap.sh ondat-cluster
 ```
 


### PR DESCRIPTION
We no longer need to install Ubuntu extras as `tcm_loop` has been added to the default kernel. 