### PR TITLE
Fix missing title on concepts page

### DIFF
--- a/docs/concepts/rolling-upgrades.md
+++ b/docs/concepts/rolling-upgrades.md
@@ -1,4 +1,5 @@
 ---
+link: Rolling Upgrades to Orchestrator
 linkTitle: "Rolling Upgrades to Orchestrator"
 ---
 


### PR DESCRIPTION
The page has a gap - turned out we missed a link title on one of the pages