### PR TITLE
Etcd TLS client cert in the same ns as storageos

### DIFF
--- a/docs/operations/etcd/storageos-secret-info.md
+++ b/docs/operations/etcd/storageos-secret-info.md
@@ -21,7 +21,7 @@ The client auth certificates need the following file names, in the Secret.
 
 ```bash
 kubectl create secret -n storageos generic \
-    etcd-client-tls \
+    storageos-etcd-secret \
     --from-file="etcd-client-ca.crt" \
     --from-file="etcd-client.crt" \
     --from-file="etcd-client.key"
@@ -45,7 +45,7 @@ spec:
     nodeContainer: "storageos/node:v2.7.0""
   namespace: "storageos"
   # External mTLS secured etcd cluster specific properties
-  tlsEtcdSecretRefName: "etcd-client-tls"                                   # Secret containing etcd client certificates in the same
+  tlsEtcdSecretRefName: "storageos-etcd-secret"                                   # Secret containing etcd client certificates in the same
   kvBackend:
     address: "https://storageos-etcd-cluster-client.storagos-etcd.svc:2379" # Etcd client service address.
     backend: "etcd"                                                         # Backend type

--- a/docs/operations/etcd/storageos-secret-info.md
+++ b/docs/operations/etcd/storageos-secret-info.md
@@ -20,7 +20,7 @@ The client auth certificates need the following file names, in the Secret.
 * etcd-client.key - containing the etcd Client key
 
 ```bash
-kubectl create secret -n storageos-etcd generic \
+kubectl create secret -n storageos generic \
     etcd-client-tls \
     --from-file="etcd-client-ca.crt" \
     --from-file="etcd-client.crt" \


### PR DESCRIPTION
The client certificate used by Ondat must be in the same namespace as Ondat, hence the default must be 'storageos'

This error didn't surface much because the etcd operator creates the secret in the right place. But if a customer has been using an external Etcd and creating a Secret with their TLS material, the command would be wrong. Before, the CR had the option to specify what NS the secret could be found, but that is no longer the case. 