### PR TITLE
Fix concepts page

### DIFF
--- a/docs/concepts/_index.md
+++ b/docs/concepts/_index.md
@@ -1,7 +1,7 @@
 ---
-title: "Concepts"
-linkTitle: "Concepts"
+title: "Features"
+linkTitle: "Features"
 weight: 200
 description: >
-    High level overview of Ondat concepts and features.
+    Overview of Ondat features.
 ---

--- a/docs/concepts/cluster-topologies.md
+++ b/docs/concepts/cluster-topologies.md
@@ -1,6 +1,7 @@
 ---
-title: "Cluster Topologies"
-linkTitle: "Cluster Topologies"
+title: "Ondat Cluster Topologies"
+linkTitle: "Ondat Cluster Topologies"
+weight: 1
 ---
 ## Overview
 

--- a/docs/concepts/clusters.md
+++ b/docs/concepts/clusters.md
@@ -1,6 +1,8 @@
 ---
 title: "Cluster"
-linkTitle: Clusters
+linkTitle: "Clusters"
+
+
 ---
 
 Ondat clusters represent groups of nodes which run a common distributed control plane.

--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -1,6 +1,7 @@
 ---
 title: "Ondat Components"
 linkTitle: "Ondat Components"
+weight: 1
 ---
 
 # Overview

--- a/docs/concepts/compression.md
+++ b/docs/concepts/compression.md
@@ -1,6 +1,7 @@
 ---
 title: "Compression"
-linkTitle: Compression
+linkTitle: "Compression"
+weight: 1
 ---
 
 Ondat compression is handled on a per volume basis and is disabled by

--- a/docs/concepts/etcd.md
+++ b/docs/concepts/etcd.md
@@ -1,9 +1,0 @@
----
-title: "Etcd"
-linkTitle: Etcd
----
-
-[Etcd](https://etcd.io) is an open-source distributed, strongly consistent key-value store that is used by Ondat to durably persist the Ondat cluster state. As the backing store for Kubernetes, Ondat uses etcd for many of the same reasons.
-
-Ondat uses etcd as the single source of truth for all Ondat objects.
-Whenever a request is made to create, update or delete an object the result is written to etcd before the request is completed. Using etcd as a configuration store allows nodes to retrieve the current cluster state after being offlined, allowing offlined nodes to rejoin the cluster.

--- a/docs/concepts/fencing.md
+++ b/docs/concepts/fencing.md
@@ -1,6 +1,7 @@
 ---
 title: "Fencing"
-linkTitle: Fencing
+linkTitle: "Fencing"
+weight: 1
 ---
 
 ## StatefulSet behaviour

--- a/docs/concepts/metric-exporter.md
+++ b/docs/concepts/metric-exporter.md
@@ -1,6 +1,7 @@
 ---
 title: "Metric Exporter"
-linkTitle: Metric Exporter
+linkTitle: "Metric Exporter"
+weight: 1
 ---
 ## Overview
 

--- a/docs/concepts/namespaces.md
+++ b/docs/concepts/namespaces.md
@@ -1,6 +1,7 @@
 ---
 title: "Namespaces"
-linkTitle: Namespaces
+linkTitle: "Namespaces"
+weight: 1
 ---
 
 Ondat namespaces are an identical concept to Kubernetes namespaces. They

--- a/docs/concepts/nodes.md
+++ b/docs/concepts/nodes.md
@@ -1,6 +1,7 @@
 ---
 title: "Nodes"
-linkTitle: Nodes
+linkTitle: "Nodes"
+weight: 1
 ---
 
 An Ondat node is any machine (virtual or physical) that is running the

--- a/docs/concepts/policies.md
+++ b/docs/concepts/policies.md
@@ -1,6 +1,7 @@
 ---
 title: "Policies"
-linkTitle: Policies
+linkTitle: "Policies"
+weight: 1
 ---
 
 Ondat policies are a way to control user and group access to Ondat

--- a/docs/concepts/replication.md
+++ b/docs/concepts/replication.md
@@ -1,6 +1,7 @@
 ---
 title: "Replication"
-linkTitle: Replication
+linkTitle: "Replication"
+weight: 1
 ---
 
 Ondat replicates volumes across nodes for data protection and high

--- a/docs/concepts/rolling-upgrades.md
+++ b/docs/concepts/rolling-upgrades.md
@@ -1,6 +1,7 @@
 ---
-link: Rolling Upgrades to Orchestrator
+title: "Rolling Upgrades to Orchestrator"
 linkTitle: "Rolling Upgrades to Orchestrator"
+weight: 1
 ---
 
 # Overview

--- a/docs/concepts/rolling-upgrades.md
+++ b/docs/concepts/rolling-upgrades.md
@@ -1,6 +1,6 @@
 ---
-title: "Rolling Upgrades to Orchestrator"
-linkTitle: "Rolling Upgrades to Orchestrator"
+title: "Ondat Rolling Upgrades Protection For Orchestrators"
+linkTitle: "Ondat Rolling Upgrades Protection For Orchestrators"
 weight: 1
 ---
 

--- a/docs/concepts/rwx.md
+++ b/docs/concepts/rwx.md
@@ -1,6 +1,6 @@
 ---
-title: "ReadWriteMany (RWX)"
-linkTitle: "ReadWriteMany (RWX)"
+title: "Ondat Files"
+linkTitle: "Ondat Files"
 weight: 1
 ---
 

--- a/docs/concepts/rwx.md
+++ b/docs/concepts/rwx.md
@@ -1,6 +1,7 @@
 ---
 title: "ReadWriteMany (RWX)"
 linkTitle: "ReadWriteMany (RWX)"
+weight: 1
 ---
 
 > ⚠️ Ondat must have a licence applied to use RWX Volumes. RWX volumes are supported on all licence tiers, including our Community Edition licence. For more information, please visit [Licensing](/docs/operations/licensing/#types-of-licenses).

--- a/docs/concepts/snapshots.md
+++ b/docs/concepts/snapshots.md
@@ -1,6 +1,7 @@
 ---
 title: "Ondat Snapshots"
-linkTitle: Ondat Snapshots
+linkTitle: "Ondat Snapshots"
+weight: 1
 ---
 
 # Overview

--- a/docs/concepts/volumes.md
+++ b/docs/concepts/volumes.md
@@ -1,6 +1,7 @@
 ---
 title: "Volumes"
-linkTitle: Volumes
+linkTitle: "Volumes"
+weight: 1
 ---
 
 Ondat volumes are a logical construct which represent a writeable volume


### PR DESCRIPTION
**First steps towards improving the Concepts page**

- Changed title of the "Concepts" page to "Features" and made the description shorter.
- Deleted the "Etcd" page as this is not necessarily a product feature but a component that is required for Ondat to work.
  - recommended redirect to be setup > https://docs.ondat.io/docs/concepts/etcd/ >>> https://docs.ondat.io/docs/prerequisites/etcd/
- Added weighting of `1` to each page (defaults to alphabetical ordering).
- Proposal/suggestion to rename the "ReadWriteMany (RWX)" page to "Ondat Files".
- Proposal/suggestion to rename the "Rolling Upgrades to Orchestrator" page to "Ondat Rolling Upgrades Protection For Orchestrators".
  - I also fixed the rendering issue for that was being caused by incorrect syntax used to define the title.