### PR TITLE
Moving pages from reference to features page

### DIFF
--- a/docs/concepts/encryption.md
+++ b/docs/concepts/encryption.md
@@ -1,6 +1,7 @@
 ---
-title: "Encryption"
-linkTitle: Encryption
+title: "Ondat Data Encryption"
+linkTitle: "Ondat Data Encryption"
+weight: 1
 ---
 
 Ondat supports encryption for data-at-rest and data-in-transit.

--- a/docs/concepts/labels.md
+++ b/docs/concepts/labels.md
@@ -1,6 +1,7 @@
 ---
-title: "Labels"
-linkTitle: Labels
+title: "Ondat Feature Labels"
+linkTitle: "Ondat Feature Labels"
+weight: 1
 ---
 
 Feature labels are a powerful and flexible way to control storage features.

--- a/docs/concepts/rolling-upgrades.md
+++ b/docs/concepts/rolling-upgrades.md
@@ -5,6 +5,8 @@ linkTitle: "Rolling Upgrades to Orchestrator"
 
 # Overview
 
+> 💡 This feature is currently available as a Technical Preview.
+
 You can use our rolling upgrade protection feature to upgrade your cluster's orchestrator without causing downtime or failure of Ondat.
 
 If the volumes containing the data for your stateful workloads do not wait to successfully synchronize in-between nodes upgrading, this can potentially cause data inconsistency and downtime. As such it is necessary to perform these upgrades intelligently.

--- a/docs/concepts/rolling-upgrades.md
+++ b/docs/concepts/rolling-upgrades.md
@@ -5,7 +5,7 @@ linkTitle: "Rolling Upgrades to Orchestrator"
 
 # Overview
 
-> 💡 This feature is currently available as a Technical Preview.
+> 💡 This feature is currently available as a Technical Preview from release `2.7.0` or greater.
 
 You can use our rolling upgrade protection feature to upgrade your cluster's orchestrator without causing downtime or failure of Ondat.
 

--- a/docs/concepts/tap.md
+++ b/docs/concepts/tap.md
@@ -1,7 +1,9 @@
 ---
-title: "Topology-Aware Placement"
-linkTitle: Topology-Aware Placement
+title: "Ondat Topology-Aware Placement"
+linkTitle: "Ondat Topology-Aware Placement"
+weight: 1
 ---
+## Overview
 
 Ondat Topology-Aware Placement is a feature that enforces placement of data
 across failure domains to guarantee high availability. Topology-Aware Placement

--- a/docs/concepts/tap.md
+++ b/docs/concepts/tap.md
@@ -1,13 +1,14 @@
 ---
-title: "Ondat Topology-Aware Placement"
-linkTitle: "Ondat Topology-Aware Placement"
+title: "Ondat Topology-Aware Placement (TAP)"
+linkTitle: "Ondat Topology-Aware Placement (TAP)"
 weight: 1
 ---
 ## Overview
 
+> 💡 This feature is available in release `v2.5.0` or greater.
+
 Ondat Topology-Aware Placement is a feature that enforces placement of data
-across failure domains to guarantee high availability. Topology-Aware Placement
-(TAP) is available from Ondat v2.5+.
+across failure domains to guarantee high availability.
 
 TAP uses default labels on nodes to define failure domains. For instance, an
 Availability Zone. However, the key label used to segment failure domains can


### PR DESCRIPTION
- I have moved the pages below (from `docs/references/`) to `docs/concepts/` as they are features of the product rather than a reference. Redirects that will be required if this PR was to be approved.
  - https://docs.ondat.io/docs/reference/tap/ >>> https://docs.ondat.io/docs/concepts/tap/
  - https://docs.ondat.io/docs/reference/labels/ >>> https://docs.ondat.io/docs/concepts/labels/
  - https://docs.ondat.io/docs/reference/encryption/ >>> https://docs.ondat.io/docs/concepts/encryption/
- I have also made small changes to titles and started adding notes on when the feature was introduced.