### PR TITLE
Fix a replica label to be a string

### DIFF
--- a/docs/operations/pooling.md
+++ b/docs/operations/pooling.md
@@ -48,7 +48,7 @@ spec:
   allowVolumeExpansion: true
   parameters:
     csi.storage.k8s.io/fstype: ext4
-    storageos.com/replicas: 1
+    storageos.com/replicas: "1"
 ```
 
 Above defines a storage pool that has 4 drives total, 2 on worker-1 (mounted to `/var/lib/storageos/nvme1` and `/var/lib/storageos/nvme2` respectively), 1 on worker-2 (mounted to `/var/lib/storageos/really-fast-nvme`) and 1 on worker-3 (mounted to `/var/lib/storageos/data/dev1`).

--- a/docs/prerequisites/systemconfiguration.md
+++ b/docs/prerequisites/systemconfiguration.md
@@ -4,7 +4,7 @@ linkTitle: System Configuration
 weight: 100
 ---
 
-Ondat requires certain standard kernel modules to function. In particular it requires [Linux-IO](http://linux-iscsi.org/wiki/Main_Page), an open-source implementation of the SCSI target, on all nodes that will execute Ondat (usually the workers).  A variety of Linux distributions are made available by AWS/Azure/GCP and other hyperscalers for use within their kubernetes platforms, however note that not all of them ship with Linux-IO.
+Ondat requires certain standard kernel modules to function. In particular it requires [Linux-IO (LIO)](https://en.wikipedia.org/wiki/LIO_(SCSI_target)), an open-source implementation of the SCSI target, on all nodes that will execute Ondat (usually the workers).  A variety of Linux distributions are made available by AWS/Azure/GCP and other hyperscalers for use within their kubernetes platforms, however note that not all of them ship with Linux-IO.
 
 ## Supported Distributions
 
@@ -34,7 +34,7 @@ We require the following modules to be loaded:
 * `target_core_user`
 * `uio`
 
-> ⚠️ Other applications utilising [TCMU](http://linux-iscsi.org/wiki/LIO) cannot be run concurrently with Ondat. Doing so may result in corruption of data. On startup, Ondat will detect if other applications are using TCMU.
+> ⚠️ Other applications utilising [TCMU]([https://docs.kernel.org/target/tcmu-design.html) cannot be run concurrently with Ondat. Doing so may result in corruption of data. On startup, Ondat will detect if other applications are using TCMU.
 
 In most modern distributions, including those listed above, the modules are distributed as part of the Linux kernel package and are included by default. In some older distributions, they were part of a kernel extras package that needed to be installed separately.
 

--- a/docs/prerequisites/systemconfiguration.md
+++ b/docs/prerequisites/systemconfiguration.md
@@ -34,7 +34,7 @@ We require the following modules to be loaded:
 * `target_core_user`
 * `uio`
 
-> ⚠️ Other applications utilising [TCMU]([https://docs.kernel.org/target/tcmu-design.html) cannot be run concurrently with Ondat. Doing so may result in corruption of data. On startup, Ondat will detect if other applications are using TCMU.
+> ⚠️ Other applications utilising [TCMU](https://docs.kernel.org/target/tcmu-design.html) cannot be run concurrently with Ondat. Doing so may result in corruption of data. On startup, Ondat will detect if other applications are using TCMU.
 
 In most modern distributions, including those listed above, the modules are distributed as part of the Linux kernel package and are included by default. In some older distributions, they were part of a kernel extras package that needed to be installed separately.
 


### PR DESCRIPTION
Integers are not accepted by the validator. The replica flag in storageos.com/replicas needs to be "1", rather than 1. 